### PR TITLE
Fix separator

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.59.0, stable]
+        rust: [stable]
     steps:
       - name: Rust install
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -43,23 +43,23 @@ jobs:
           cargo fmt --all -- --check
           cargo clippy -- -D warnings
 
-      - name: Install cargo check tools
-        timeout-minutes: 20
-        if: ${{ matrix.rust == 'stable' }}
-        run: |
-          cargo install --locked cargo-outdated || true
-          # cargo install --locked cargo-udeps || true # needs nightly
-          cargo install --locked cargo-audit || true
-          cargo install --locked cargo-pants || true
+      # - name: Install cargo check tools
+      #   timeout-minutes: 20
+      #   if: ${{ matrix.rust == 'stable' }}
+      #   run: |
+      #     cargo install --locked cargo-outdated || true
+      #     # cargo install --locked cargo-udeps || true # needs nightly
+      #     cargo install --locked cargo-audit || true
+      #     cargo install --locked cargo-pants || true
 
-      - name: Check
-        if: ${{ matrix.rust == 'stable' }}
-        run: |
-          cargo outdated --exit-code 1
-          # cargo udeps
-          rm -rf ~/.cargo/advisory-db
-          cargo audit --ignore RUSTSEC-2020-0071 # time-rs, but not used by chrono, see https://github.com/chronotope/chrono/issues/602
-          cargo pants
+      # - name: Check
+      #   if: ${{ matrix.rust == 'stable' }}
+      #   run: |
+      #     cargo outdated --exit-code 1
+      #     # cargo udeps
+      #     rm -rf ~/.cargo/advisory-db
+      #     cargo audit --ignore RUSTSEC-2020-0071 # time-rs, but not used by chrono, see https://github.com/chronotope/chrono/issues/602
+      #     cargo pants
 
       - name: Build (dev)
         run: cargo build --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
+checksum = "0da5b41ee986eed3f524c380e6d64965aea573882a8907682ad100f7859305ca"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -57,15 +57,14 @@ dependencies = [
  "async-lock",
  "blocking",
  "futures-lite",
- "num_cpus",
  "once_cell",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab006897723d9352f63e2b13047177c3982d8d79709d713ce7747a8f19fd1b0"
+checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
 dependencies = [
  "autocfg",
  "concurrent-queue",
@@ -228,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -254,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -344,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -359,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -369,15 +368,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -386,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -407,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -418,21 +417,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -481,13 +480,14 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -611,20 +611,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "os_str_bytes"
@@ -769,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
+checksum = "89f31df3f50926cdf2855da5fd8812295c34752cb20438dae42a67f79e021ac3"
 dependencies = [
  "indexmap",
  "itoa",
@@ -816,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -883,18 +873,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 u0xy
+   Copyright 2022 graelo
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 u0xy
+Copyright (c) 2022 graelo
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![crate](https://img.shields.io/crates/v/tmux-backup.svg)](https://crates.io/crates/tmux-backup)
 [![documentation](https://docs.rs/tmux-backup/badge.svg)](https://docs.rs/tmux-backup)
-[![minimum rustc 1.8](https://img.shields.io/badge/rustc-1.50+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.50](https://img.shields.io/badge/rustc-1.50+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![rust 2021 edition](https://img.shields.io/badge/edition-2021-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)
 [![build status](https://github.com/graelo/tmux-backup/workflows/main/badge.svg)](https://github.com/graelo/tmux-backup/actions)
 
 <!-- cargo-sync-readme start -->

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -28,18 +28,18 @@ if ! check_version $MSRV ; then
 fi
 
 FEATURES=()
-# check_version 1.27 && FEATURES+=(libm)
+# check_version 1.59 && FEATURES+=(libm)
 echo "Testing supported features: ${FEATURES[*]}"
 
 set -x
 
 # test the default
 cargo build
-cargo test
+cargo test --workspace
 
 # test `no_std`
 cargo build --no-default-features
-cargo test --no-default-features
+cargo test --no-default-features --workspace
 
 # test each isolated feature, with and without std
 for feature in "${FEATURES[@]}"; do
@@ -47,7 +47,7 @@ for feature in "${FEATURES[@]}"; do
   # cargo test --no-default-features --features="std $feature"
 
   cargo build --no-default-features --features="$feature"
-  cargo test --no-default-features --features="$feature"
+  cargo test --no-default-features --features="$feature" --workspace
 done
 
 # test all supported features, with and without std
@@ -55,4 +55,4 @@ done
 # cargo test --features="std ${FEATURES[*]}"
 
 cargo build --features="${FEATURES[*]}"
-cargo test --features="${FEATURES[*]}"
+cargo test --features="${FEATURES[*]}" --workspace

--- a/tmux-lib/LICENSE-APACHE
+++ b/tmux-lib/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 u0xy
+   Copyright 2022 graelo
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/tmux-lib/LICENSE-MIT
+++ b/tmux-lib/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 u0xy
+Copyright (c) 2022 graelo
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tmux-lib/src/client.rs
+++ b/tmux-lib/src/client.rs
@@ -7,7 +7,7 @@ use nom::{character::complete::char, combinator::all_consuming, sequence::tuple}
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::Error,
+    error::{map_add_intent, Error},
     parse::{quoted_nonempty_string, quoted_string},
     Result,
 };
@@ -43,10 +43,13 @@ impl FromStr for Client {
     ///
     /// For definitions, look at `Pane` type and the tmux man page for
     /// definitions.
-    fn from_str(src: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
+        let desc = "Client";
+        let intent = "'#{client_session}':'#{client_last_session}'";
+        let parser = tuple((quoted_nonempty_string, char(':'), quoted_string));
+
         let (_, (session_name, _, last_session_name)) =
-            all_consuming(tuple((quoted_nonempty_string, char(':'), quoted_string)))(src)
-                .map_err(|_| Error::ParseWindowIdError(src.to_string()))?;
+            all_consuming(parser)(input).map_err(|e| map_add_intent(desc, intent, e))?;
 
         Ok(Client {
             session_name: session_name.to_string(),
@@ -54,6 +57,10 @@ impl FromStr for Client {
         })
     }
 }
+
+// ------------------------------
+// Ops
+// ------------------------------
 
 /// Return the current client useful attributes.
 pub async fn current_client() -> Result<Client> {

--- a/tmux-lib/src/error.rs
+++ b/tmux-lib/src/error.rs
@@ -20,6 +20,30 @@ pub enum Error {
     #[error("unexpected process output: `{0}`")]
     UnexpectedOutput(String),
 
+    /// Failed parsing a PaneId.
+    #[error("failed parsing PaneId from `{0}`")]
+    ParsePaneIdError(String),
+
+    /// Failed parsing a Pane.
+    #[error("failed parsing Pane from `{0}`")]
+    ParsePaneError(String),
+
+    /// Failed parsing a WindowId.
+    #[error("failed parsing WindowId from `{0}`")]
+    ParseWindowIdError(String),
+
+    /// Failed parsing a Window.
+    #[error("failed parsing Window from `{0}`")]
+    ParseWindowError(String),
+
+    /// Failed parsing a SessionId.
+    #[error("failed parsing SessionId from `{0}`")]
+    ParseSessionIdError(String),
+
+    /// Failed parsing a Session.
+    #[error("failed parsing Session from `{0}`")]
+    ParseSessionError(String),
+
     /// Indicates Tmux has a weird config, like missing the `"default-shell"`.
     #[error("unexpected tmux config: `{0}`")]
     TmuxConfig(&'static str),

--- a/tmux-lib/src/error.rs
+++ b/tmux-lib/src/error.rs
@@ -1,52 +1,30 @@
-use std::io;
+use std::{io, process::Output};
 
 /// Describes all errors variants from this crate.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    /// Failed parsing a tmux id marker for sessions, windows or panes.
-    #[error("expected a tmux id marker `{0}`")]
-    ExpectedIdMarker(char),
-
-    /// Failed parsing an integer from a tmux response.
-    #[error("failed parsing int")]
-    ExpectedInt(#[from] std::num::ParseIntError),
-
-    /// Failed parsing a bool from a tmux response.
-    #[error("failed parsing bool")]
-    ExpectedBool(#[from] std::str::ParseBoolError),
-
     /// A tmux invocation returned some output where none was expected (actions such as
     /// some `tmux display-message` invocations).
-    #[error("unexpected process output: `{0}`")]
-    UnexpectedOutput(String),
-
-    /// Failed parsing a PaneId.
-    #[error("failed parsing PaneId from `{0}`")]
-    ParsePaneIdError(String),
-
-    /// Failed parsing a Pane.
-    #[error("failed parsing Pane from `{0}`")]
-    ParsePaneError(String),
-
-    /// Failed parsing a WindowId.
-    #[error("failed parsing WindowId from `{0}`")]
-    ParseWindowIdError(String),
-
-    /// Failed parsing a Window.
-    #[error("failed parsing Window from `{0}`")]
-    ParseWindowError(String),
-
-    /// Failed parsing a SessionId.
-    #[error("failed parsing SessionId from `{0}`")]
-    ParseSessionIdError(String),
-
-    /// Failed parsing a Session.
-    #[error("failed parsing Session from `{0}`")]
-    ParseSessionError(String),
+    #[error(
+        "unexpected process output: intent: `{intent}`, stdout: `{stdout}`, stderr: `{stderr}`"
+    )]
+    UnexpectedTmuxOutput {
+        intent: &'static str,
+        stdout: String,
+        stderr: String,
+    },
 
     /// Indicates Tmux has a weird config, like missing the `"default-shell"`.
     #[error("unexpected tmux config: `{0}`")]
     TmuxConfig(&'static str),
+
+    /// Some parsing error.
+    #[error("failed parsing: `{intent}`")]
+    ParseError {
+        desc: &'static str,
+        intent: &'static str,
+        err: nom::Err<nom::error::Error<String>>,
+    },
 
     /// Failed parsing the output of a process invocation as utf-8.
     #[error("failed parsing utf-8 string: `{source}`")]
@@ -63,4 +41,33 @@ pub enum Error {
         /// Source error.
         source: io::Error,
     },
+}
+
+/// Convert a nom error into an owned error and add the parsing intent.
+pub fn map_add_intent(
+    desc: &'static str,
+    intent: &'static str,
+    nom_err: nom::Err<nom::error::Error<&str>>,
+) -> Error {
+    Error::ParseError {
+        desc,
+        intent,
+        err: nom_err.to_owned(),
+    }
+}
+
+pub fn check_empty_process_output(
+    output: Output,
+    intent: &'static str,
+) -> std::result::Result<(), Error> {
+    if !output.stdout.is_empty() || !output.stderr.is_empty() {
+        let stdout = String::from_utf8_lossy(&output.stdout[..]).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr[..]).to_string();
+        return Err(Error::UnexpectedTmuxOutput {
+            intent,
+            stdout,
+            stderr,
+        });
+    }
+    Ok(())
 }

--- a/tmux-lib/src/layout.rs
+++ b/tmux-lib/src/layout.rs
@@ -131,7 +131,7 @@ pub fn parse_window_layout(input: &str) -> Result<WindowLayout> {
     }
 }
 
-fn window_layout(input: &str) -> IResult<&str, WindowLayout> {
+pub(crate) fn window_layout(input: &str) -> IResult<&str, WindowLayout> {
     let (input, (id, _, container)) = tuple((layout_id, char(','), container))(input)?;
     Ok((input, WindowLayout { id, container }))
 }

--- a/tmux-lib/src/lib.rs
+++ b/tmux-lib/src/lib.rs
@@ -37,6 +37,7 @@ pub use client::display_message;
 pub mod layout;
 pub mod pane;
 pub mod pane_id;
+pub(crate) mod parse;
 pub mod server;
 pub mod session;
 pub mod session_id;

--- a/tmux-lib/src/pane.rs
+++ b/tmux-lib/src/pane.rs
@@ -7,11 +7,22 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use async_std::process::Command;
+use nom::{
+    character::complete::{char, digit1, not_line_ending},
+    combinator::map_res,
+    sequence::tuple,
+    IResult,
+};
 use serde::{Deserialize, Serialize};
 
 use super::pane_id::PaneId;
 use super::window_id::WindowId;
-use crate::{error, Result};
+use crate::{
+    error::Error,
+    pane_id::pane_id,
+    parse::{boolean, quoted_nonempty_string},
+    Result,
+};
 
 /// A Tmux pane.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,18 +33,6 @@ pub struct Pane {
     pub index: u16,
     /// Describes if the pane is currently active (focused).
     pub is_active: bool,
-    /// Number of columns in the pane.
-    pub width: u16,
-    /// Number of lines in the pane.
-    pub height: u16,
-    /// Position (column) of the left of the Pane
-    pub pos_left: u16,
-    /// Position (column) of the right of the Pane
-    pub pos_right: u16,
-    /// Position (row) of the top of the Pane
-    pub pos_top: u16,
-    /// Position (row) of the bottom of the Pane
-    pub pos_bottom: u16,
     /// Title of the Pane (usually defaults to the hostname)
     pub title: String,
     /// Current dirpath of the Pane
@@ -43,7 +42,7 @@ pub struct Pane {
 }
 
 impl FromStr for Pane {
-    type Err = error::Error;
+    type Err = Error;
 
     /// Parse a string containing tmux panes status into a new `Pane`.
     ///
@@ -53,64 +52,35 @@ impl FromStr for Pane {
     /// The expected format of the tmux status is
     ///
     /// ```text
-    /// %20:0:false:175:85:0:174:0:84:rmbp:/Users/graelo/code/rust/tmux-backup:nvim
-    /// %21:1:true:158:42:176:333:0:41:rmbp:/Users/graelo/code/rust/tmux-backup:tmux
-    /// %27:2:false:158:42:176:333:43:84:rmbp:/Users/graelo/code/rust/tmux-backup:man
+    /// %20:0:false:'rmbp':'nvim':/Users/graelo/code/rust/tmux-backup
+    /// %21:1:true:'rmbp':'tmux':/Users/graelo/code/rust/tmux-backup
+    /// %27:2:false:'rmbp':'man man':/Users/graelo/code/rust/tmux-backup
     /// ```
     ///
     /// This status line is obtained with
     ///
     /// ```text
-    /// tmux list-panes -F "#{pane_id}:#{pane_index}:#{?pane_active,true,false}:#{pane_width}:#{pane_height}:#{pane_left}:#{pane_right}:#{pane_top}:#{pane_bottom}:#{pane_title}:#{pane_current_path}:#{pane_current_command}"
+    /// tmux list-panes -F "#{pane_id}:#{pane_index}:#{?pane_active,true,false}:'#{pane_title}':'#{pane_current_command}':#{pane_current_path}"
     /// ```
     ///
     /// For definitions, look at `Pane` type and the tmux man page for
     /// definitions.
     fn from_str(src: &str) -> std::result::Result<Self, Self::Err> {
-        let items: Vec<&str> = src.split(':').collect();
-        assert_eq!(
-            items.len(),
-            12,
-            "tmux should have returned 12 items per line"
-        );
+        // if let Ok((input, pane)) = session(src) && input.is_empty(){
+        //     return Ok(pane);
+        // }
+        // Err(Error::ParseSessionError(src.into()))
 
-        let mut iter = items.iter();
-
-        // Pane id must be start with '%' followed by a `u32`
-        let id_str = iter.next().unwrap();
-        let id = PaneId::from_str(id_str)?;
-
-        let index = iter.next().unwrap().parse::<u16>()?;
-
-        let is_active = iter.next().unwrap().parse::<bool>()?;
-
-        let width = iter.next().unwrap().parse::<u16>()?;
-        let height = iter.next().unwrap().parse::<u16>()?;
-
-        let pos_left = iter.next().unwrap().parse::<u16>()?;
-        let pos_right = iter.next().unwrap().parse::<u16>()?;
-        let pos_top = iter.next().unwrap().parse::<u16>()?;
-        let pos_bottom = iter.next().unwrap().parse::<u16>()?;
-
-        let title = iter.next().unwrap().to_string();
-
-        let path = PathBuf::from(iter.next().unwrap());
-        let command = iter.next().unwrap().to_string();
-
-        Ok(Pane {
-            id,
-            index,
-            is_active,
-            width,
-            height,
-            pos_left,
-            pos_right,
-            pos_top,
-            pos_bottom,
-            title,
-            dirpath: path,
-            command,
-        })
+        match pane(src) {
+            Ok((input, pane)) => {
+                if input.is_empty() {
+                    Ok(pane)
+                } else {
+                    Err(Error::ParsePaneError(src.to_string()))
+                }
+            }
+            Err(_) => Err(Error::ParsePaneError(src.to_string())),
+        }
     }
 }
 
@@ -163,11 +133,9 @@ pub async fn available_panes() -> Result<Vec<Pane>> {
         "#{pane_id}\
         :#{pane_index}\
         :#{?pane_active,true,false}\
-        :#{pane_width}:#{pane_height}\
-        :#{pane_left}:#{pane_right}:#{pane_top}:#{pane_bottom}\
-        :#{pane_title}\
-        :#{pane_current_path}\
-        :#{pane_current_command}",
+        :'#{pane_title}'\
+        :'#{pane_current_command}'\
+        :#{pane_current_path}",
     ];
 
     let output = Command::new("tmux").args(&args).output().await?;
@@ -182,6 +150,34 @@ pub async fn available_panes() -> Result<Vec<Pane>> {
         .collect();
 
     result
+}
+
+pub(crate) fn pane(input: &str) -> IResult<&str, Pane> {
+    let (input, (id, _, index, _, is_active, _, title, _, command, _, dirpath)) = tuple((
+        pane_id,
+        char(':'),
+        map_res(digit1, str::parse),
+        char(':'),
+        boolean,
+        char(':'),
+        quoted_nonempty_string,
+        char(':'),
+        quoted_nonempty_string,
+        char(':'),
+        not_line_ending,
+    ))(input)?;
+
+    Ok((
+        input,
+        Pane {
+            id,
+            index,
+            is_active,
+            title: title.into(),
+            dirpath: dirpath.into(),
+            command: command.into(),
+        },
+    ))
 }
 
 /// Create a new pane (horizontal split) in the window with `window_id`, and return the new
@@ -222,7 +218,7 @@ pub async fn select_pane(pane_id: &PaneId) -> Result<()> {
     let buffer = String::from_utf8(output.stdout)?;
 
     if !buffer.is_empty() {
-        return Err(error::Error::UnexpectedOutput(buffer));
+        return Err(Error::UnexpectedOutput(buffer));
     }
     Ok(())
 }
@@ -238,9 +234,9 @@ mod tests {
     #[test]
     fn parse_list_panes() {
         let output = vec![
-            "%20:0:false:175:85:0:174:0:84:rmbp:/Users/graelo/code/rust/tmux-backup:nvim",
-            "%21:1:true:158:42:176:333:0:41:rmbp:/Users/graelo/code/rust/tmux-backup:tmux",
-            "%27:2:false:158:42:176:333:43:84:rmbp:/Users/graelo/code/rust/tmux-backup:man",
+            "%20:0:false:'rmbp':'nvim':/Users/graelo/code/rust/tmux-backup",
+            "%21:1:true:'graelo@server: ~':'tmux':/Users/graelo/code/rust/tmux-backup",
+            "%27:2:false:'rmbp':'man man':/Users/graelo/code/rust/tmux-backup",
         ];
         let panes: Result<Vec<Pane>> = output.iter().map(|&line| Pane::from_str(line)).collect();
         let panes = panes.expect("Could not parse tmux panes");
@@ -250,12 +246,6 @@ mod tests {
                 id: PaneId::from_str("%20").unwrap(),
                 index: 0,
                 is_active: false,
-                width: 175,
-                height: 85,
-                pos_left: 0,
-                pos_right: 174,
-                pos_top: 0,
-                pos_bottom: 84,
                 title: String::from("rmbp"),
                 dirpath: PathBuf::from_str("/Users/graelo/code/rust/tmux-backup").unwrap(),
                 command: String::from("nvim"),
@@ -264,13 +254,7 @@ mod tests {
                 id: PaneId(String::from("%21")),
                 index: 1,
                 is_active: true,
-                width: 158,
-                height: 42,
-                pos_left: 176,
-                pos_right: 333,
-                pos_top: 0,
-                pos_bottom: 41,
-                title: String::from("rmbp"),
+                title: String::from("graelo@server: ~"),
                 dirpath: PathBuf::from_str("/Users/graelo/code/rust/tmux-backup").unwrap(),
                 command: String::from("tmux"),
             },
@@ -278,15 +262,9 @@ mod tests {
                 id: PaneId(String::from("%27")),
                 index: 2,
                 is_active: false,
-                width: 158,
-                height: 42,
-                pos_left: 176,
-                pos_right: 333,
-                pos_top: 43,
-                pos_bottom: 84,
                 title: String::from("rmbp"),
                 dirpath: PathBuf::from_str("/Users/graelo/code/rust/tmux-backup").unwrap(),
-                command: String::from("man"),
+                command: String::from("man man"),
             },
         ];
 

--- a/tmux-lib/src/parse.rs
+++ b/tmux-lib/src/parse.rs
@@ -1,0 +1,61 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{escaped, tag},
+    character::complete::none_of,
+    combinator::value,
+    sequence::delimited,
+    IResult,
+};
+
+/// Return the `&str` between single quotes. The returned string may be empty.
+#[allow(unused)]
+pub(crate) fn quoted_string(input: &str) -> IResult<&str, &str> {
+    let esc = escaped(none_of("\\\'"), '\\', tag("'"));
+    let esc_or_empty = alt((esc, tag("")));
+
+    delimited(tag("'"), esc_or_empty, tag("'"))(input)
+}
+
+/// Return the `&str` between single quotes. The returned string may not be empty.
+pub(crate) fn quoted_nonempty_string(input: &str) -> IResult<&str, &str> {
+    let esc = escaped(none_of("\\\'"), '\\', tag("'"));
+    delimited(tag("'"), esc, tag("'"))(input)
+}
+
+/// Return a bool: allowed values: `"true"` or `"false"`.
+pub(crate) fn boolean(input: &str) -> IResult<&str, bool> {
+    // This is a parser that returns `true` if it sees the string "true", and
+    // an error otherwise.
+    let parse_true = value(true, tag("true"));
+
+    let parse_false = value(false, tag("false"));
+
+    alt((parse_true, parse_false))(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quoted_nonempty_string() {
+        let (input, res) = quoted_nonempty_string(r#"'foo\' 🤖 bar'"#).unwrap();
+        assert!(input.is_empty());
+        assert_eq!(res, r#"foo\' 🤖 bar"#);
+        let (input, res) = quoted_nonempty_string("'λx → x'").unwrap();
+        assert!(input.is_empty());
+        assert_eq!(res, "λx → x");
+        let (input, res) = quoted_nonempty_string("'  '").unwrap();
+        assert!(input.is_empty());
+        assert_eq!(res, "  ");
+
+        assert!(quoted_nonempty_string("''").is_err());
+    }
+
+    #[test]
+    fn test_quoted_string() {
+        let (input, res) = quoted_string("''").unwrap();
+        assert!(input.is_empty());
+        assert!(res.is_empty());
+    }
+}

--- a/tmux-lib/src/session_id.rs
+++ b/tmux-lib/src/session_id.rs
@@ -1,16 +1,16 @@
 //! Session Id.
 
-use std::fmt;
 use std::str::FromStr;
 
 use nom::{
     character::complete::{char, digit1},
+    combinator::all_consuming,
     sequence::preceded,
     IResult,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::error::{map_add_intent, Error};
 
 /// The id of a Tmux session.
 ///
@@ -23,22 +23,14 @@ impl FromStr for SessionId {
 
     /// Parse into SessionId. The `&str` must start with '$' followed by a
     /// `u16`.
-    fn from_str(src: &str) -> std::result::Result<Self, Self::Err> {
-        // if let Ok((input, sess_id)) = session_id(src) && input.is_empty(){
-        //     return Ok(sess_id);
-        // }
-        // Err(Error::ParseSessionIdError(src.into()))
+    fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
+        let desc = "SessionId";
+        let intent = "#{session_id}";
 
-        match session_id(src) {
-            Ok((input, sess_id)) => {
-                if input.is_empty() {
-                    Ok(sess_id)
-                } else {
-                    Err(Error::ParseSessionIdError(src.into()))
-                }
-            }
-            Err(_) => Err(Error::ParseSessionIdError(src.into())),
-        }
+        let (_, sess_id) =
+            all_consuming(parse::session_id)(input).map_err(|e| map_add_intent(desc, intent, e))?;
+
+        Ok(sess_id)
     }
 }
 
@@ -48,16 +40,14 @@ impl FromStr for SessionId {
 //     }
 // }
 
-impl fmt::Display for SessionId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+pub(crate) mod parse {
+    use super::*;
 
-pub fn session_id(input: &str) -> IResult<&str, SessionId> {
-    let (input, digit) = preceded(char('$'), digit1)(input)?;
-    let id = format!("${}", digit);
-    Ok((input, SessionId(id)))
+    pub fn session_id(input: &str) -> IResult<&str, SessionId> {
+        let (input, digit) = preceded(char('$'), digit1)(input)?;
+        let id = format!("${}", digit);
+        Ok((input, SessionId(id)))
+    }
 }
 
 #[cfg(test)]
@@ -66,11 +56,11 @@ mod tests {
 
     #[test]
     fn test_parse_session_id_fn() {
-        let actual = session_id("$43");
+        let actual = parse::session_id("$43");
         let expected = Ok(("", SessionId("$43".into())));
         assert_eq!(actual, expected);
 
-        let actual = session_id("$4");
+        let actual = parse::session_id("$4");
         let expected = Ok(("", SessionId("$4".into())));
         assert_eq!(actual, expected);
     }
@@ -82,6 +72,13 @@ mod tests {
         assert_eq!(actual.unwrap(), SessionId("$43".into()));
 
         let actual = SessionId::from_str("4:38");
-        assert!(matches!(actual, Err(Error::ParseSessionIdError(string)) if string == *"4:38"));
+        assert!(matches!(
+            actual,
+            Err(Error::ParseError {
+                desc: "SessionId",
+                intent: "#{session_id}",
+                err: _
+            })
+        ));
     }
 }

--- a/tmux-lib/src/session_id.rs
+++ b/tmux-lib/src/session_id.rs
@@ -3,6 +3,11 @@
 use std::fmt;
 use std::str::FromStr;
 
+use nom::{
+    character::complete::{char, digit1},
+    sequence::preceded,
+    IResult,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -19,12 +24,21 @@ impl FromStr for SessionId {
     /// Parse into SessionId. The `&str` must start with '$' followed by a
     /// `u16`.
     fn from_str(src: &str) -> std::result::Result<Self, Self::Err> {
-        if !src.starts_with('$') {
-            return Err(Error::ExpectedIdMarker('$'));
+        // if let Ok((input, sess_id)) = session_id(src) && input.is_empty(){
+        //     return Ok(sess_id);
+        // }
+        // Err(Error::ParseSessionIdError(src.into()))
+
+        match session_id(src) {
+            Ok((input, sess_id)) => {
+                if input.is_empty() {
+                    Ok(sess_id)
+                } else {
+                    Err(Error::ParseSessionIdError(src.into()))
+                }
+            }
+            Err(_) => Err(Error::ParseSessionIdError(src.into())),
         }
-        let id = src[1..].parse::<u16>()?;
-        let id = format!("${}", id);
-        Ok(SessionId(id))
     }
 }
 
@@ -37,5 +51,37 @@ impl FromStr for SessionId {
 impl fmt::Display for SessionId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+pub fn session_id(input: &str) -> IResult<&str, SessionId> {
+    let (input, digit) = preceded(char('$'), digit1)(input)?;
+    let id = format!("${}", digit);
+    Ok((input, SessionId(id)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_session_id_fn() {
+        let actual = session_id("$43");
+        let expected = Ok(("", SessionId("$43".into())));
+        assert_eq!(actual, expected);
+
+        let actual = session_id("$4");
+        let expected = Ok(("", SessionId("$4".into())));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_parse_session_id_struct() {
+        let actual = SessionId::from_str("$43");
+        assert!(actual.is_ok());
+        assert_eq!(actual.unwrap(), SessionId("$43".into()));
+
+        let actual = SessionId::from_str("4:38");
+        assert!(matches!(actual, Err(Error::ParseSessionIdError(string)) if string == *"4:38"));
     }
 }


### PR DESCRIPTION
- [x] names are quoted so that pane names such as `server$: ~` can be saved
- [x] use the `nom` crate instead of custom parsing