### PR TITLE
refactor configuration (breaking change)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,11 +82,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -600,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
 
 [[package]]
 name = "link-cplusplus"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 A backup & restore solution for Tmux sessions.
 
-Version requirement: _rustc 1.50+_
+Version requirement: _rustc 1.56+_
 
 ```toml
 [dependencies]
-tmux-backup = "0.1"
+tmux-backup = "0.3"
 ```
 
 ## Features
@@ -25,7 +25,7 @@ tmux-backup = "0.1"
 - Fast: less than 1 sec for 16 sessions, 45 windows and 80 panes.
 - Show the catalog of backups, with age, file size, content description & archive format
 - 2 strategies are available:
-  - keep the `k` most recent backups
+  - keep the `n` most recent backups
   - classic backup strategy:
     - the lastest backup per hour for the past 24 hours (max 23 backups - exclude the past hour),
     - the lastest backup per day for the past 7 days (max 6 backups - exclude the past 24 hours),
@@ -108,15 +108,10 @@ On linux
 
 ```shell
 curl \
-    https://github.com/graelo/tmux-backup/releases/download/v0.1.0/tmux-backup-x86_64-unknown-linux-gnu.tar.xz \
+    https://github.com/graelo/tmux-backup/releases/download/v0.3.0/tmux-backup-x86_64-unknown-linux-gnu.tar.xz \
     | tar xf - > /usr/local/bin/tmux-backup
 chmod +x /usr/local/bin/tmux-backup
 ```
-
-In your shell profile, add one of the following environment variables
-
-- `TMUX_BACKUP_STRATEGY_MOST_RECENT=10`
-- `TMUX_BACKUP_STRATEGY_CLASSIC=true`
 
 If you use tpm, copy the file `tmux-backup.tmux` to `~/.tmux/plugins/tmux-backup/tmux-backup.tmux` and
 declare the tmux-backup plugin to TPM in your `~/.tmux.conf`:

--- a/src/actions/save.rs
+++ b/src/actions/save.rs
@@ -92,9 +92,11 @@ async fn save_panes_content<P: AsRef<Path>>(
 
     for pane in panes {
         let dest_dir = destination_dir.as_ref().to_path_buf();
+        // TODO: improve this heuristic, maybe with config
+        let drop_n_last_lines = if pane.command == "zsh" { 1 } else { 0 };
+
         let handle = task::spawn(async move {
-            let should_drop_last_line = pane.command == "zsh";
-            let output = pane.capture(should_drop_last_line).await.unwrap();
+            let output = pane.capture(drop_n_last_lines).await.unwrap();
 
             let filename = format!("pane-{}.txt", pane.id);
             let filepath = dest_dir.join(filename);

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,7 +141,6 @@ pub struct Config {
     /// the lastest per month of this year.
     #[clap(
         group = "strategy",
-        short = 'l',
         long = "strategy-classic",
         value_parser,
         env = "TMUX_BACKUP_STRATEGY_CLASSIC"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 
 //! A backup & restore solution for Tmux sessions.
 //!
-//! Version requirement: _rustc 1.50+_
+//! Version requirement: _rustc 1.56+_
 //!
 //! ```toml
 //! [dependencies]
-//! tmux-backup = "0.1"
+//! tmux-backup = "0.3"
 //! ```
 //!
 //! ## Features
@@ -17,7 +17,7 @@
 //! - Fast: less than 1 sec for 16 sessions, 45 windows and 80 panes.
 //! - Show the catalog of backups, with age, file size, content description & archive format
 //! - 2 strategies are available:
-//!   - keep the `k` most recent backups
+//!   - keep the `n` most recent backups
 //!   - classic backup strategy:
 //!     - the lastest backup per hour for the past 24 hours (max 23 backups - exclude the past hour),
 //!     - the lastest backup per day for the past 7 days (max 6 backups - exclude the past 24 hours),
@@ -100,15 +100,10 @@
 //!
 //! ```shell
 //! curl \
-//!     https://github.com/graelo/tmux-backup/releases/download/v0.1.0/tmux-backup-x86_64-unknown-linux-gnu.tar.xz \
+//!     https://github.com/graelo/tmux-backup/releases/download/v0.3.0/tmux-backup-x86_64-unknown-linux-gnu.tar.xz \
 //!     | tar xf - > /usr/local/bin/tmux-backup
 //! chmod +x /usr/local/bin/tmux-backup
 //! ```
-//!
-//! In your shell profile, add one of the following environment variables
-//!
-//! - `TMUX_BACKUP_STRATEGY_MOST_RECENT=10`
-//! - `TMUX_BACKUP_STRATEGY_CLASSIC=true`
 //!
 //! If you use tpm, copy the file `tmux-backup.tmux` to `~/.tmux/plugins/tmux-backup/tmux-backup.tmux` and
 //! declare the tmux-backup plugin to TPM in your `~/.tmux.conf`:

--- a/src/management/catalog.rs
+++ b/src/management/catalog.rs
@@ -43,12 +43,13 @@ impl Catalog {
     /// - The catalog only manages backup files such as `backup-20220804T221153.tar.zst`, other
     /// files are simply ignored (and in principle, should not be present).
     pub async fn new<P: AsRef<Path>>(dirpath: P, strategy: Strategy) -> Result<Catalog> {
-        fs::create_dir_all(dirpath.as_ref()).await?;
+        let dirpath = dirpath.as_ref();
+        fs::create_dir_all(dirpath).await?;
 
-        let backup_files = Self::parse_backup_filenames(dirpath.as_ref()).await?;
+        let backup_files = Self::parse_backup_filenames(dirpath).await?;
 
         let catalog = Catalog {
-            dirpath: dirpath.as_ref().to_path_buf(),
+            dirpath: dirpath.to_path_buf(),
             strategy,
             backups: backup_files,
         };

--- a/tmux-backup.tmux
+++ b/tmux-backup.tmux
@@ -56,7 +56,7 @@ keyswitch=$(tmux show-option -gv @backup-keyswitch)
 keytable=$(tmux show-option -gv @backup-keytable)
 tmux bind-key ${keyswitch} switch-client -T ${keytable}
 
-setup_option "strategy" "-k 10"
+setup_option "strategy" "-s most-recent -n 10"
 strategy=$(tmux show-option -gv @backup-strategy)
 
 #
@@ -66,23 +66,22 @@ strategy=$(tmux show-option -gv @backup-strategy)
 function setup_binding() {
     local key=$1
     local command="$2"
-    # tmux bind-key -T ${keytable} ${key} new-window -d -n ${window_name} "${BINARY} --window-name '"${window_name}"' --reverse --unique-hint ${pattern_arg}"
-    tmux bind-key -T ${keytable} ${key} run-shell "${BINARY} ${strategy} ${command}"
+    tmux bind-key -T ${keytable} ${key} run-shell "${BINARY} ${command}"
 }
 
 function setup_binding_w_popup() {
     local key=$1
     local command="$2"
-    tmux bind-key -T ${keytable} ${key} display-popup -E "tmux new-session -A -s tmux-backup '${BINARY} ${strategy} ${command} ; echo Press any key... && read -k1 -s'"
+    tmux bind-key -T ${keytable} ${key} display-popup -E "tmux new-session -A -s tmux-backup '${BINARY} ${command} ; echo Press any key... && read -k1 -s'"
 }
 
 # prefix + b + b only saves a new backup without compacting the catalog
-setup_binding "b" "save --to-tmux"
+setup_binding "b" "save ${strategy} --to-tmux"
 # prefix + b + s saves a new backup and compacts the catalog
-setup_binding "s" "save --compact --to-tmux"
+setup_binding "s" "save ${strategy} --compact --to-tmux"
 # prefix + b + r restores the most recent backup
-setup_binding "r" "restore --to-tmux"
+setup_binding "r" "restore ${strategy} --to-tmux"
 # prefix + b + l prints the catalog without details
-setup_binding_w_popup "l" "catalog list"
+setup_binding_w_popup "l" "catalog ${strategy} list"
 # prefix + b + L prints the catalog
-setup_binding_w_popup "L" "catalog list --details"
+setup_binding_w_popup "L" "catalog ${strategy} list --details"

--- a/tmux-lib/src/lib.rs
+++ b/tmux-lib/src/lib.rs
@@ -41,6 +41,7 @@ pub(crate) mod parse;
 pub mod server;
 pub mod session;
 pub mod session_id;
+pub(crate) mod utils;
 pub mod window;
 pub mod window_id;
 

--- a/tmux-lib/src/utils.rs
+++ b/tmux-lib/src/utils.rs
@@ -1,0 +1,61 @@
+/// Misc utilities.
+
+pub(crate) trait SliceExt {
+    fn trim(&self) -> &Self;
+    fn trim_trailing(&self) -> &Self;
+}
+
+fn is_whitespace(c: &u8) -> bool {
+    *c == b'\t' || *c == b' '
+}
+
+fn is_not_whitespace(c: &u8) -> bool {
+    !is_whitespace(c)
+}
+
+impl SliceExt for [u8] {
+    /// Trim leading and trailing whitespaces (`\t` and ` `) in a `&[u8]`
+    fn trim(&self) -> &[u8] {
+        if let Some(first) = self.iter().position(is_not_whitespace) {
+            if let Some(last) = self.iter().rposition(is_not_whitespace) {
+                &self[first..last + 1]
+            } else {
+                unreachable!();
+            }
+        } else {
+            &[]
+        }
+    }
+
+    /// Trim trailing whitespaces (`\t` and ` `) in a `&[u8]`
+    fn trim_trailing(&self) -> &[u8] {
+        if let Some(last) = self.iter().rposition(is_not_whitespace) {
+            &self[0..last + 1]
+        } else {
+            &[]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SliceExt;
+
+    #[test]
+    fn trims_trailing_whitespaces() {
+        let input = "  text   ".as_bytes();
+        let expected = "  text".as_bytes();
+
+        let actual = input.trim_trailing();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn trims_whitespaces() {
+        let input = "  text   ".as_bytes();
+        let expected = "text".as_bytes();
+
+        let actual = input.trim();
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
- choice of a strategy is not global anymore but is now
  specific to commands save, list, restore
- default strategy is now most-recent, with n = 10

In practice, this means the following commands work
out of the box

```sh
tmux-backup catalog list
tmux-backup save
tmux-backup restore
```

but they can take strategy options:

```sh
tmux-backup catalog -n 12 list
tmux-backup save -s classic
tmux-backup save -n 13 --compact
tmux-backup restore -s most-recent -n 18
```