### PR TITLE
Add droplines

### DIFF
--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.59.0, beta, nightly]
+        rust: [1.60.0, beta, nightly]
 
     steps:
       - name: Rust install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.136"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "link-cplusplus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 name = "tmux-backup"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.60.0"
 description = "A backup & restore solution for Tmux sessions."
 readme = "README.md"
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=tmux-backup
-MSRV=1.59
+MSRV=1.60
 
 get_rust_version() {
   local array=($(rustc --version));
@@ -28,7 +28,7 @@ if ! check_version $MSRV ; then
 fi
 
 FEATURES=()
-# check_version 1.59 && FEATURES+=(libm)
+# check_version 1.60 && FEATURES+=(libm)
 echo "Testing supported features: ${FEATURES[*]}"
 
 set -x

--- a/src/bin/tmux-backup.rs
+++ b/src/bin/tmux-backup.rs
@@ -69,10 +69,11 @@ async fn run(config: Config) {
             strategy,
             to_tmux,
             compact,
+            num_lines_to_drop,
         } => {
             let catalog = init_catalog(&config.backup_dirpath, strategy).await;
 
-            match save(&catalog.dirpath).await {
+            match save(&catalog.dirpath, num_lines_to_drop as usize).await {
                 Ok((backup_filepath, archive_overview)) => {
                     if compact {
                         // In practice this should never fail: write to the catalog already ensures

--- a/src/bin/tmux-backup.rs
+++ b/src/bin/tmux-backup.rs
@@ -22,9 +22,8 @@ async fn init_catalog<P: AsRef<Path>>(
         Err(e) => {
             failure_message(
                 format!(
-                    "🛑 Catalog error at `{}`: {}",
-                    backup_dirpath.as_ref().to_string_lossy(),
-                    e
+                    "🛑 Catalog error at `{}`: {e}",
+                    backup_dirpath.as_ref().to_string_lossy()
                 ),
                 Output::Both,
             );
@@ -54,7 +53,7 @@ async fn run(config: Config) {
                         success_message(message, Output::Stdout)
                     }
                     Err(e) => failure_message(
-                        format!("🛑 Could not compact backups: {}", e),
+                        format!("🛑 Could not compact backups: {e}"),
                         Output::Stdout,
                     ),
                 },
@@ -93,7 +92,7 @@ async fn run(config: Config) {
                     success_message(message, to_tmux);
                 }
                 Err(e) => {
-                    failure_message(format!("🛑 Could not save sessions: {}", e), to_tmux);
+                    failure_message(format!("🛑 Could not save sessions: {e}"), to_tmux);
                 }
             };
         }
@@ -125,7 +124,7 @@ async fn run(config: Config) {
                     success_message(message, to_tmux)
                 }
                 Err(e) => {
-                    failure_message(format!("🛑 Could not restore sessions: {}", e), to_tmux);
+                    failure_message(format!("🛑 Could not restore sessions: {e}"), to_tmux);
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ impl fmt::Display for StrategyValues {
             Self::MostRecent => "most-recent",
             Self::Classic => "classic",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,24 @@ pub enum Command {
         /// Delete purgeable backups after saving.
         #[clap(long, action = ArgAction::SetTrue)]
         compact: bool,
+
+        /// Number of lines to ignore during capture if the active command is a shell.
+        ///
+        /// At the time of saving, for each pane where the active command is one of (`zsh`, `bash`,
+        /// `fish`), the shell prompt is waiting for input. If tmux-backup naively captures the
+        /// entire history, on restoring that backup, a new shell prompt will also appear. This
+        /// obviously pollutes history with repeated shell prompts.
+        ///
+        /// If you know the number of lines your shell prompt occupies on screen, set this option
+        /// to that number (simply `1` in my case). These last lines will not be captured. On
+        /// restore, this gives the illusion of history continuity without repetition.
+        #[clap(
+            short = 'i',
+            long = "ignore-last-lines",
+            value_name = "NUMBER",
+            default_value_t = 0
+        )]
+        num_lines_to_drop: u8,
     },
 
     /// Restore the Tmux sessions from a backup file.

--- a/src/management/archive/v1.rs
+++ b/src/management/archive/v1.rs
@@ -51,7 +51,7 @@ impl Metadata {
     /// Query Tmux and return a new `Metadata`.
     pub async fn new() -> Result<Self> {
         let version = FORMAT_VERSION.to_string();
-        let client = tmux::client::current_client().await?;
+        let client = tmux::client::current().await?;
         let sessions = tmux::session::available_sessions().await?;
         let windows = tmux::window::available_windows().await?;
         let panes = tmux::pane::available_panes().await?;

--- a/src/management/backup.rs
+++ b/src/management/backup.rs
@@ -75,7 +75,7 @@ impl Backup {
             return "1 minute".into();
         }
 
-        format!("{} seconds", duration_secs)
+        format!("{duration_secs} seconds")
     }
 }
 

--- a/src/management/compaction.rs
+++ b/src/management/compaction.rs
@@ -170,7 +170,7 @@ impl fmt::Display for Strategy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Strategy::KeepMostRecent { k } => {
-                write!(f, "KeepMostRecent: {}", k)
+                write!(f, "KeepMostRecent: {k}")
             }
             Strategy::Classic => write!(f, "Classic"),
         }

--- a/tmux-backup.tmux
+++ b/tmux-backup.tmux
@@ -76,9 +76,9 @@ function setup_binding_w_popup() {
 }
 
 # prefix + b + b only saves a new backup without compacting the catalog
-setup_binding "b" "save ${strategy} --to-tmux"
+setup_binding "b" "save ${strategy} --ignore-last-lines 1 --to-tmux"
 # prefix + b + s saves a new backup and compacts the catalog
-setup_binding "s" "save ${strategy} --compact --to-tmux"
+setup_binding "s" "save ${strategy} --ignore-last-lines 1 --compact --to-tmux"
 # prefix + b + r restores the most recent backup
 setup_binding "r" "restore ${strategy} --to-tmux"
 # prefix + b + l prints the catalog without details

--- a/tmux-backup.tmux
+++ b/tmux-backup.tmux
@@ -8,11 +8,11 @@
 #
 #   set -g @backup-keytable "foobar"
 #   set -g @backup-keyswitch "z"
-#   set -g @backup-strategy "-k 10"
+#   set -g @backup-strategy "-s most-recent -n 10"
 #
 # and bindings like
 #
-#   bind-key -T foobar l 'tmux-backup -k 10 catalog list'
+#   bind-key -T foobar l 'tmux-backup catalog list'
 #
 # You can also entirely ignore this file (not even source it) and define all
 # options and bindings in your `tmux.conf`.

--- a/tmux-lib/src/client.rs
+++ b/tmux-lib/src/client.rs
@@ -63,7 +63,11 @@ impl FromStr for Client {
 // ------------------------------
 
 /// Return the current client useful attributes.
-pub async fn current_client() -> Result<Client> {
+///
+/// # Errors
+///
+/// Returns an `io::IOError` in the command failed.
+pub async fn current() -> Result<Client> {
     let args = vec![
         "display-message",
         "-p",

--- a/tmux-lib/src/error.rs
+++ b/tmux-lib/src/error.rs
@@ -44,6 +44,11 @@ pub enum Error {
 }
 
 /// Convert a nom error into an owned error and add the parsing intent.
+///
+/// # Errors
+///
+/// This maps to a `Error::ParseError`.
+#[must_use]
 pub fn map_add_intent(
     desc: &'static str,
     intent: &'static str,
@@ -56,8 +61,14 @@ pub fn map_add_intent(
     }
 }
 
+/// Ensure that the output's stdout and stderr are empty, indicating
+/// the command had succeeded.
+///
+/// # Errors
+///
+/// Returns a `Error::UnexpectedTmuxOutput` in case .
 pub fn check_empty_process_output(
-    output: Output,
+    output: &Output,
     intent: &'static str,
 ) -> std::result::Result<(), Error> {
     if !output.stdout.is_empty() || !output.stderr.is_empty() {

--- a/tmux-lib/src/layout.rs
+++ b/tmux-lib/src/layout.rs
@@ -33,6 +33,7 @@ pub struct WindowLayout {
 
 impl WindowLayout {
     /// Return a flat list of pane ids.
+    #[must_use]
     pub fn pane_ids(&self) -> Vec<u16> {
         let mut acc: Vec<u16> = vec![];
         acc.reserve(1);

--- a/tmux-lib/src/pane.rs
+++ b/tmux-lib/src/pane.rs
@@ -108,7 +108,7 @@ impl Pane {
         let mut trimmed_lines: Vec<&[u8]> = output
             .stdout
             .split(|c| *c == b'\n')
-            .map(|line| line.trim_trailing())
+            .map(SliceExt::trim_trailing) // .map(|line| line.trim_trailing())
             .collect();
 
         trimmed_lines.truncate(trimmed_lines.len() - drop_n_last_lines);
@@ -117,11 +117,11 @@ impl Pane {
         let mut output_trimmed: Vec<u8> = Vec::with_capacity(output.stdout.len());
         for (idx, &line) in trimmed_lines.iter().enumerate() {
             output_trimmed.extend_from_slice(line);
-            if idx != trimmed_lines.len() - 1 {
-                output_trimmed.push(b'\n');
-            } else {
+            if idx == trimmed_lines.len() {
                 let reset = "\u{001b}[0m".as_bytes();
                 output_trimmed.extend_from_slice(reset);
+            } else {
+                output_trimmed.push(b'\n');
             }
         }
 
@@ -228,7 +228,7 @@ pub async fn select_pane(pane_id: &PaneId) -> Result<()> {
     let args = vec!["select-pane", "-t", pane_id.as_str()];
 
     let output = Command::new("tmux").args(&args).output().await?;
-    check_empty_process_output(output, "select-pane")
+    check_empty_process_output(&output, "select-pane")
 }
 
 #[cfg(test)]

--- a/tmux-lib/src/pane.rs
+++ b/tmux-lib/src/pane.rs
@@ -105,27 +105,45 @@ impl Pane {
 
         let output = Command::new("tmux").args(&args).output().await?;
 
-        let mut trimmed_lines: Vec<&[u8]> = output
-            .stdout
-            .split(|c| *c == b'\n')
-            .map(SliceExt::trim_trailing) // .map(|line| line.trim_trailing())
-            .collect();
-
-        trimmed_lines.truncate(trimmed_lines.len() - drop_n_last_lines);
+        let trimmed_lines: Vec<&[u8]> = Self::buf_trim_trailing(&output.stdout);
+        let mut buffer: Vec<&[u8]> = Self::drop_last_empty_lines(&trimmed_lines);
+        buffer.truncate(buffer.len() - drop_n_last_lines);
 
         // Join the lines with `b'\n'`, add reset code to the last line
-        let mut output_trimmed: Vec<u8> = Vec::with_capacity(output.stdout.len());
-        for (idx, &line) in trimmed_lines.iter().enumerate() {
-            output_trimmed.extend_from_slice(line);
-            if idx == trimmed_lines.len() {
+        let mut final_buffer: Vec<u8> = Vec::with_capacity(output.stdout.len());
+        for (idx, &line) in buffer.iter().enumerate() {
+            final_buffer.extend_from_slice(line);
+
+            let is_last_line = idx == buffer.len() - 1;
+            if is_last_line {
                 let reset = "\u{001b}[0m".as_bytes();
-                output_trimmed.extend_from_slice(reset);
+                final_buffer.extend_from_slice(reset);
+                final_buffer.push(b'\n');
             } else {
-                output_trimmed.push(b'\n');
+                final_buffer.push(b'\n');
             }
         }
 
-        Ok(output_trimmed)
+        Ok(final_buffer)
+    }
+
+    /// Trim each line of the buffer.
+    pub(crate) fn buf_trim_trailing(buf: &[u8]) -> Vec<&[u8]> {
+        let trimmed_lines: Vec<&[u8]> = buf
+            .split(|c| *c == b'\n')
+            .map(SliceExt::trim_trailing) // trim each line
+            .collect();
+
+        trimmed_lines
+    }
+
+    /// Drop all the last empty lines.
+    pub(crate) fn drop_last_empty_lines<'a>(lines: &[&'a [u8]]) -> Vec<&'a [u8]> {
+        if let Some(last) = lines.iter().rposition(|line| !line.is_empty()) {
+            lines[0..=last].to_vec()
+        } else {
+            lines.to_vec()
+        }
     }
 }
 
@@ -277,5 +295,32 @@ mod tests {
         ];
 
         assert_eq!(panes, expected);
+    }
+
+    #[test]
+    fn test_buf_trim_trailing() {
+        let text = "line1\n\nline3   ";
+        let actual = Pane::buf_trim_trailing(text.as_bytes());
+        let expected = vec!["line1".as_bytes(), "".as_bytes(), "line3".as_bytes()];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_buf_drop_last_empty_lines() {
+        let text = "line1\nline2\n\nline3   ";
+
+        let trimmed_lines = Pane::buf_trim_trailing(text.as_bytes());
+        let actual = Pane::drop_last_empty_lines(&trimmed_lines);
+        let expected = trimmed_lines;
+        assert_eq!(actual, expected);
+
+        //
+
+        let text = "line1\nline2\n\n\n     ";
+
+        let trimmed_lines = Pane::buf_trim_trailing(text.as_bytes());
+        let actual = Pane::drop_last_empty_lines(&trimmed_lines);
+        let expected = vec!["line1".as_bytes(), "line2".as_bytes()];
+        assert_eq!(actual, expected);
     }
 }

--- a/tmux-lib/src/pane_id.rs
+++ b/tmux-lib/src/pane_id.rs
@@ -58,7 +58,7 @@ pub(crate) mod parse {
 
     pub(crate) fn pane_id(input: &str) -> IResult<&str, PaneId> {
         let (input, digit) = preceded(char('%'), digit1)(input)?;
-        let id = format!("%{}", digit);
+        let id = format!("%{digit}");
         Ok((input, PaneId(id)))
     }
 }

--- a/tmux-lib/src/pane_id.rs
+++ b/tmux-lib/src/pane_id.rs
@@ -22,7 +22,7 @@ pub struct PaneId(pub String);
 impl FromStr for PaneId {
     type Err = Error;
 
-    /// Parse into PaneId. The `&str` must start with '%' followed by a `u32`.
+    /// Parse into `PaneId`. The `&str` must start with '%' followed by a `u32`.
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let desc = "PaneId";
         let intent = "#{pane_id}";
@@ -42,6 +42,7 @@ impl From<&u16> for PaneId {
 
 impl PaneId {
     /// Extract a string slice containing the raw representation.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -54,7 +55,7 @@ impl fmt::Display for PaneId {
 }
 
 pub(crate) mod parse {
-    use super::*;
+    use super::{char, digit1, preceded, IResult, PaneId};
 
     pub(crate) fn pane_id(input: &str) -> IResult<&str, PaneId> {
         let (input, digit) = preceded(char('%'), digit1)(input)?;

--- a/tmux-lib/src/server.rs
+++ b/tmux-lib/src/server.rs
@@ -21,7 +21,7 @@ pub async fn start(initial_session_name: &str) -> Result<()> {
     let args = vec!["new-session", "-d", "-s", initial_session_name];
 
     let output = Command::new("tmux").args(&args).output().await?;
-    check_empty_process_output(output, "new-session")
+    check_empty_process_output(&output, "new-session")
 }
 
 /// Remove the session named `"[placeholder]"` used to keep the server alive.
@@ -30,7 +30,7 @@ pub async fn kill_session(name: &str) -> Result<()> {
     let args = vec!["kill-session", "-t", &exact_name];
 
     let output = Command::new("tmux").args(&args).output().await?;
-    check_empty_process_output(output, "kill-session")
+    check_empty_process_output(&output, "kill-session")
 }
 
 /// Return the value of a Tmux option. For instance, this can be used to get Tmux's default

--- a/tmux-lib/src/server.rs
+++ b/tmux-lib/src/server.rs
@@ -85,7 +85,7 @@ pub async fn default_command() -> Result<String> {
         .map(|cmd| cmd.to_owned())
         .map(|cmd| {
             if cmd.ends_with("bash") {
-                format!("-l {}", cmd)
+                format!("-l {cmd}")
             } else {
                 cmd
             }

--- a/tmux-lib/src/session_id.rs
+++ b/tmux-lib/src/session_id.rs
@@ -45,7 +45,7 @@ pub(crate) mod parse {
 
     pub fn session_id(input: &str) -> IResult<&str, SessionId> {
         let (input, digit) = preceded(char('$'), digit1)(input)?;
-        let id = format!("${}", digit);
+        let id = format!("${digit}");
         Ok((input, SessionId(id)))
     }
 }

--- a/tmux-lib/src/window.rs
+++ b/tmux-lib/src/window.rs
@@ -211,7 +211,7 @@ pub async fn set_layout(layout: &str, window_id: &WindowId) -> Result<()> {
     let args = vec!["select-layout", "-t", window_id.as_str(), layout];
 
     let output = Command::new("tmux").args(&args).output().await?;
-    check_empty_process_output(output, "select-layout")
+    check_empty_process_output(&output, "select-layout")
 }
 
 /// Select (make active) the window with `window_id`.
@@ -219,7 +219,7 @@ pub async fn select_window(window_id: &WindowId) -> Result<()> {
     let args = vec!["select-window", "-t", window_id.as_str()];
 
     let output = Command::new("tmux").args(&args).output().await?;
-    check_empty_process_output(output, "select-window")
+    check_empty_process_output(&output, "select-window")
 }
 
 #[cfg(test)]

--- a/tmux-lib/src/window_id.rs
+++ b/tmux-lib/src/window_id.rs
@@ -46,7 +46,7 @@ pub(crate) mod parse {
 
     pub(crate) fn window_id(input: &str) -> IResult<&str, WindowId> {
         let (input, digit) = preceded(char('@'), digit1)(input)?;
-        let id = format!("@{}", digit);
+        let id = format!("@{digit}");
         Ok((input, WindowId(id)))
     }
 }


### PR DESCRIPTION
Ability to `n` drop lines when the shell prompt is the active command.

At the time of saving, for each pane where the active command is one of (`zsh`, `bash`,
`fish`), the shell prompt is waiting for input. If tmux-backup naively captures the
entire history, on restoring that backup, a new shell prompt will also appear. This
obviously pollutes history with repeated shell prompts.
                                                                                        
If you know the number of lines your shell prompt occupies on screen, set this option
to that number (simply `1` in my case). These last lines will not be captured. On
restore, this gives the illusion of history continuity without repetition.
