### PR TITLE
feat(backup)!: name contains timestamp with microsecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,22 +26,22 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "event-listener",
  "futures-core",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
- "concurrent-queue",
+ "concurrent-queue 2.0.0",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -68,7 +68,7 @@ checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "futures-lite",
  "libc",
  "log",
@@ -198,9 +198,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ca34107f97baef6cfb231b32f36115781856b8f8208e8c580e0bcaea374842"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 dependencies = [
  "jobserver",
 ]
@@ -289,6 +289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -673,9 +682,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
 name = "parking"
@@ -978,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "tmux-lib"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746097ec40eee5d978503883fd8d38208f4e1e065619b03f7f9330418644f144"
+checksum = "16571c0073e0153eb7a41785216eae24257a6d7ee5e94786d61797fa6afa5dcb"
 dependencies = [
  "async-std",
  "nom",

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ Strategy: KeepMostRecent: 10
 Location: `$HOME/.local/state/tmux-backup`
 
      NAME                             AGE         STATUS       FILESIZE    VERSION  CONTENT
- 11. backup-20220907T224553.tar.zst   2 days      purgeable    644.17 kB   1.0      16 sessions 43 windows 79 panes
- 10. backup-20220907T224926.tar.zst   2 days      retainable   644.38 kB   1.0      16 sessions 43 windows 79 panes
-  9. backup-20220908T092341.tar.zst   2 days      retainable   654.76 kB   1.0      16 sessions 43 windows 79 panes
-  8. backup-20220909T224742.tar.zst   18 hours    retainable   599.64 kB   1.0      16 sessions 42 windows 77 panes
-  7. backup-20220909T225158.tar.zst   18 hours    retainable   600.32 kB   1.0      16 sessions 42 windows 79 panes
-  6. backup-20220910T152551.tar.zst   1 hour      retainable   608.79 kB   1.0      16 sessions 43 windows 80 panes
-  5. backup-20220910T165118.tar.zst   29 minutes  retainable   614.16 kB   1.0      16 sessions 43 windows 80 panes
-  4. backup-20220910T171812.tar.zst   2 minutes   retainable   614.33 kB   1.0      16 sessions 43 windows 80 panes
-  3. backup-20220910T172016.tar.zst   11 seconds  retainable   614.44 kB   1.0      16 sessions 43 windows 80 panes
-  2. backup-20220910T172019.tar.zst   8 seconds   retainable   614.42 kB   1.0      16 sessions 43 windows 80 panes
-  1. backup-20220910T172024.tar.zst   3 seconds   retainable   614.38 kB   1.0      16 sessions 43 windows 80 panes
+ 11. backup-20220907T224553.156103.tar.zst   2 days      purgeable    644.17 kB   1.0      16 sessions 43 windows 79 panes
+ 10. backup-20220907T224926.103771.tar.zst   2 days      retainable   644.38 kB   1.0      16 sessions 43 windows 79 panes
+  9. backup-20220908T092341.125258.tar.zst   2 days      retainable   654.76 kB   1.0      16 sessions 43 windows 79 panes
+  8. backup-20220909T224742.781818.tar.zst   18 hours    retainable   599.64 kB   1.0      16 sessions 42 windows 77 panes
+  7. backup-20220909T225158.305403.tar.zst   18 hours    retainable   600.32 kB   1.0      16 sessions 42 windows 79 panes
+  6. backup-20220910T152551.807672.tar.zst   1 hour      retainable   608.79 kB   1.0      16 sessions 43 windows 80 panes
+  5. backup-20220910T165118.250800.tar.zst   29 minutes  retainable   614.16 kB   1.0      16 sessions 43 windows 80 panes
+  4. backup-20220910T171812.893389.tar.zst   2 minutes   retainable   614.33 kB   1.0      16 sessions 43 windows 80 panes
+  3. backup-20220910T172016.924711.tar.zst   11 seconds  retainable   614.44 kB   1.0      16 sessions 43 windows 80 panes
+  2. backup-20220910T172019.320809.tar.zst   8 seconds   retainable   614.42 kB   1.0      16 sessions 43 windows 80 panes
+  1. backup-20220910T172024.141993.tar.zst   3 seconds   retainable   614.38 kB   1.0      16 sessions 43 windows 80 panes
 
 11 backups: 10 retainable, 1 purgeable
 ```
@@ -73,7 +73,7 @@ Both of these bindings will open a tmux popup showing the catalog content.
 
 ```console
 $ tmux-backup save
-✅ 16 sessions 43 windows 80 panes, persisted to `/Users/graelo/.local/state/tmux-backup/backup-20220910T171812.tar.zst`
+✅ 16 sessions 43 windows 80 panes, persisted to `/Users/graelo/.local/state/tmux-backup/backup-20220910T171812.893389.tar.zst`
 ```
 
 By default, the tmux binding for saving a new backup are

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,17 +38,17 @@
 //! Location: `$HOME/.local/state/tmux-backup`
 //!
 //!      NAME                             AGE         STATUS       FILESIZE    VERSION  CONTENT
-//!  11. backup-20220907T224553.tar.zst   2 days      purgeable    644.17 kB   1.0      16 sessions 43 windows 79 panes
-//!  10. backup-20220907T224926.tar.zst   2 days      retainable   644.38 kB   1.0      16 sessions 43 windows 79 panes
-//!   9. backup-20220908T092341.tar.zst   2 days      retainable   654.76 kB   1.0      16 sessions 43 windows 79 panes
-//!   8. backup-20220909T224742.tar.zst   18 hours    retainable   599.64 kB   1.0      16 sessions 42 windows 77 panes
-//!   7. backup-20220909T225158.tar.zst   18 hours    retainable   600.32 kB   1.0      16 sessions 42 windows 79 panes
-//!   6. backup-20220910T152551.tar.zst   1 hour      retainable   608.79 kB   1.0      16 sessions 43 windows 80 panes
-//!   5. backup-20220910T165118.tar.zst   29 minutes  retainable   614.16 kB   1.0      16 sessions 43 windows 80 panes
-//!   4. backup-20220910T171812.tar.zst   2 minutes   retainable   614.33 kB   1.0      16 sessions 43 windows 80 panes
-//!   3. backup-20220910T172016.tar.zst   11 seconds  retainable   614.44 kB   1.0      16 sessions 43 windows 80 panes
-//!   2. backup-20220910T172019.tar.zst   8 seconds   retainable   614.42 kB   1.0      16 sessions 43 windows 80 panes
-//!   1. backup-20220910T172024.tar.zst   3 seconds   retainable   614.38 kB   1.0      16 sessions 43 windows 80 panes
+//!  11. backup-20220907T224553.156103.tar.zst   2 days      purgeable    644.17 kB   1.0      16 sessions 43 windows 79 panes
+//!  10. backup-20220907T224926.103771.tar.zst   2 days      retainable   644.38 kB   1.0      16 sessions 43 windows 79 panes
+//!   9. backup-20220908T092341.125258.tar.zst   2 days      retainable   654.76 kB   1.0      16 sessions 43 windows 79 panes
+//!   8. backup-20220909T224742.781818.tar.zst   18 hours    retainable   599.64 kB   1.0      16 sessions 42 windows 77 panes
+//!   7. backup-20220909T225158.305403.tar.zst   18 hours    retainable   600.32 kB   1.0      16 sessions 42 windows 79 panes
+//!   6. backup-20220910T152551.807672.tar.zst   1 hour      retainable   608.79 kB   1.0      16 sessions 43 windows 80 panes
+//!   5. backup-20220910T165118.250800.tar.zst   29 minutes  retainable   614.16 kB   1.0      16 sessions 43 windows 80 panes
+//!   4. backup-20220910T171812.893389.tar.zst   2 minutes   retainable   614.33 kB   1.0      16 sessions 43 windows 80 panes
+//!   3. backup-20220910T172016.924711.tar.zst   11 seconds  retainable   614.44 kB   1.0      16 sessions 43 windows 80 panes
+//!   2. backup-20220910T172019.320809.tar.zst   8 seconds   retainable   614.42 kB   1.0      16 sessions 43 windows 80 panes
+//!   1. backup-20220910T172024.141993.tar.zst   3 seconds   retainable   614.38 kB   1.0      16 sessions 43 windows 80 panes
 //!
 //! 11 backups: 10 retainable, 1 purgeable
 //! ```
@@ -65,7 +65,7 @@
 //!
 //! ```console
 //! $ tmux-backup save
-//! ✅ 16 sessions 43 windows 80 panes, persisted to `/Users/graelo/.local/state/tmux-backup/backup-20220910T171812.tar.zst`
+//! ✅ 16 sessions 43 windows 80 panes, persisted to `/Users/graelo/.local/state/tmux-backup/backup-20220910T171812.893389.tar.zst`
 //! ```
 //!
 //! By default, the tmux binding for saving a new backup are

--- a/src/management/archive/v1.rs
+++ b/src/management/archive/v1.rs
@@ -192,7 +192,7 @@ pub fn new_backup_filepath<P>(dirpath: P) -> PathBuf
 where
     P: AsRef<Path>,
 {
-    let timestamp_frag = Local::now().format("%Y%m%dT%H%M%S").to_string();
+    let timestamp_frag = Local::now().format("%Y%m%dT%H%M%S%.f").to_string();
     let backup_filename = format!("backup-{timestamp_frag}.tar.zst");
     dirpath.as_ref().join(backup_filename)
 }

--- a/src/management/catalog.rs
+++ b/src/management/catalog.rs
@@ -188,7 +188,7 @@ impl Catalog {
     async fn parse_backup_filenames<P: AsRef<Path>>(dirpath: P) -> Result<Vec<Backup>> {
         let mut backups: Vec<Backup> = vec![];
 
-        let pattern = r#".*backup-(\d{8}T\d{6})\.tar\.zst"#;
+        let pattern = r#".*backup-(\d{8}T\d{6})\.\d{6}\.tar\.zst"#;
         let matcher = Regex::new(pattern).unwrap();
 
         let mut entries = fs::read_dir(dirpath.as_ref()).await?;
@@ -198,7 +198,7 @@ impl Catalog {
             if let Some(captures) = matcher.captures(&path.to_string_lossy()) {
                 let date_str = &captures[1];
                 let creation_date =
-                    NaiveDateTime::parse_from_str(date_str, "%Y%m%dT%H%M%S").unwrap();
+                    NaiveDateTime::parse_from_str(date_str, "%Y%m%dT%H%M%S%.f").unwrap();
                 let backup = Backup {
                     filepath: path.into(),
                     creation_date,


### PR DESCRIPTION
This breaking change makes things more robust,
but you have to rename your backup files by adding a microseconds suffix, such as `.123456`.

You can do so with

```sh
autoload -U zmv
zmv 'backup-(*).tar.zst' 'backup-${1}.123456.tar.zst'
```