### PR TITLE
chore(ci): further cleanup

### DIFF
--- a/.github/workflows/check-outdated.yml
+++ b/.github/workflows/check-outdated.yml
@@ -1,6 +1,6 @@
 # Runs cargo-outdated when the `check-outdated` label is added to a PR
 
-name: Check outdated dependencies
+name: Outdated
 on:
   workflow_dispatch:
   pull_request_target:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-outdated:
-    name: Check outdated dependencies
+    name: Check outdated deps
     runs-on: ubuntu-latest
     if: github.event.label.name == 'check-outdated'
     steps:

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -60,8 +60,10 @@ jobs:
           rm convco
 
       - name: Quality - cargo deny check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/latest | jq -r '.tag_name')
+          VERSION=$(gh api repos/EmbarkStudios/cargo-deny/releases/latest --jq '.tag_name')
           curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
             tar zx --no-anchored cargo-deny --strip-components=1
           chmod +x cargo-deny


### PR DESCRIPTION
Replace unauthenticated curl calls to api.github.com with gh api to
avoid rate-limit 404s in CI. Shorten check-outdated workflow name to
match the project's naming convention.
