### PR TITLE
chore(ci): change Renovate schedule to Fridays at 16:00 UTC

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,7 +6,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * 1' # every Monday at 07:00 UTC
+    - cron: '0 16 * * 5' # every Friday at 16:00 UTC
 
 jobs:
   renovate:

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,6 @@
     }
   ],
   "schedule": [
-    "before 9am on monday"
+    "before 9pm on friday"
   ]
 }


### PR DESCRIPTION
Move Renovate's automated dependency updates from Monday mornings to Friday afternoons.

The previous schedule ran every Monday at 07:00 UTC with a constraint to finish before 9am. This has been updated to run on Fridays at 16:00 UTC with a constraint to finish before 9pm, spreading the workload across the week.

Changes:
- Updated GitHub Actions workflow cron expression
- Updated renovate.json schedule constraints