### PR TITLE
fix(test): remove const_is_empty assertions flagged by clippy on rust 1.88

### DIFF
--- a/src/actions/restore.rs
+++ b/src/actions/restore.rs
@@ -237,7 +237,6 @@ mod tests {
 
         #[test]
         fn placeholder_session_name_is_not_empty() {
-            assert!(!PLACEHOLDER_SESSION_NAME.is_empty());
             // Should have content between the brackets
             assert!(PLACEHOLDER_SESSION_NAME.len() > 2);
         }
@@ -296,7 +295,7 @@ mod tests {
             };
 
             // Just verify it doesn't panic - Debug is derived
-            let debug_str = format!("{:?}", pair);
+            let debug_str = format!("{pair:?}");
             assert!(debug_str.contains("Pair"));
         }
 

--- a/src/actions/save.rs
+++ b/src/actions/save.rs
@@ -231,10 +231,5 @@ mod tests {
             assert!(DETECTED_SHELLS.contains(&"bash"));
             assert!(DETECTED_SHELLS.contains(&"fish"));
         }
-
-        #[test]
-        fn detected_shells_is_not_empty() {
-            assert!(!DETECTED_SHELLS.is_empty());
-        }
     }
 }

--- a/src/management/archive/v1.rs
+++ b/src/management/archive/v1.rs
@@ -417,12 +417,11 @@ mod tests {
         fn format_version_is_semver_like() {
             // Ensure version looks like "X.Y" or similar
             assert!(FORMAT_VERSION.contains('.'));
-            assert!(!FORMAT_VERSION.is_empty());
         }
 
         #[test]
         fn panes_dir_name_is_reasonable() {
-            assert!(!PANES_DIR_NAME.is_empty());
+            assert_eq!(PANES_DIR_NAME, "panes-content");
             assert!(!PANES_DIR_NAME.contains('/'));
             assert!(!PANES_DIR_NAME.contains('\\'));
         }


### PR DESCRIPTION
Clippy on Rust 1.88 flags `!CONST.is_empty()` with `const_is_empty`,
a lint that was later removed in newer Rust versions. This breaks CI
which runs with `-D warnings`.

Removed the redundant assertions — they were already covered by stronger
checks in the same tests (e.g. `len() > 2`, `contains('.')`, or replaced
with `assert_eq!`). Also inlined a format arg flagged by
`uninlined_format_args`.