### PR TITLE
fix(ci): configure renovate repository and git author

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Run Renovate
         uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d # v46.1.8
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           configurationFile: renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "gitAuthor": "Renovate Bot <84066822+graelo@users.noreply.github.com>",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
The self-hosted Renovate action was warning "No repositories found"
because it needs an explicit RENOVATE_REPOSITORIES env var when run
as a GitHub Action (unlike the Mend-hosted app which auto-discovers).

Also set a custom gitAuthor using the GitHub noreply address so
Renovate commits show as "Verified" instead of being attributed to
the shared Mend account email.