### PR TITLE
chore(ci): disable renovate vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,9 @@
   "cargo": {
     "enabled": true
   },
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "description": "Group all patch updates into one PR",


### PR DESCRIPTION
Disable Renovate's vulnerabilityAlerts feature, which requires
reading GitHub's Dependabot alerts API. Fine-grained PATs don't
support the needed permission, and vulnerability scanning is already
handled by cargo-audit in the essentials workflow.