### PR TITLE
ci: remove cache from release workflow to prevent cache poisoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,17 +44,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache crates from crates.io
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: '${{ runner.os }}-${{ matrix.target }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles(''**/Cargo.lock'') }}'
 
       - name: Build Release
         run: cargo build --release


### PR DESCRIPTION
zizmor flagged actions/cache in the release job as vulnerable to cache
poisoning — a malicious PR could poison the shared cache, and the next
release build would use tainted artifacts. Removed the cache step so
release builds always start clean. Slightly slower, but release builds
are infrequent and integrity matters more than speed here.