### PR TITLE
ci: harden workflows with least-privilege permissions and zizmor fixes

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -7,10 +7,14 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     name: Quality checks & tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust: [stable]
@@ -27,6 +31,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           # fetch-depth: ${{ github.event.pull_request.commits }}
+          persist-credentials: false
 
       - name: Cache crates from crates.io
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -6,10 +6,14 @@ on:
     branches:
       - staging
 
+permissions: {}
+
 jobs:
   test-versions:
     name: Tests on Linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust: [1.88.0, beta, nightly]
@@ -23,6 +27,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Cache crates from crates.io
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -56,6 +62,8 @@ jobs:
   test-other-platforms:
     name: Tests on
     runs-on: '${{ matrix.os }}'
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -77,6 +85,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Cache crates from crates.io
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,15 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   prepare-artifacts:
     name: Prepare release artifacts
     # if: github.ref == 'refs/heads/main'
     runs-on: '${{ matrix.os }}'
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -43,18 +47,26 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
-
+          persist-credentials: false
 
       - name: Build Release
         run: cargo build --release
 
       - name: Compress to zip (macOS)
         if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' }}
-        run: zip -A ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }} target/release/${{ github.event.repository.name }}
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          TARGET: ${{ matrix.target }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+        run: zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "target/release/${REPO_NAME}"
 
       - name: Compress to tar.xz (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
-        run: tar Jcf ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }} target/release/${{ github.event.repository.name }}
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          TARGET: ${{ matrix.target }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+        run: tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "target/release/${REPO_NAME}"
 
       - name: List files
         run: |
@@ -82,6 +94,7 @@ jobs:
         with:
           # convco needs all history to create the changelog
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version
         id: extract-version
@@ -123,6 +136,8 @@ jobs:
     name: Bump Homebrew formula
     # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - release
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,13 +8,21 @@ on:
   schedule:
     - cron: '0 16 * * 5' # every Friday at 16:00 UTC
 
+permissions: {}
+
 jobs:
   renovate:
     name: Renovate
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Renovate
         uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d # v46.1.8


### PR DESCRIPTION
Address 19 of 21 open zizmor code-scanning alerts across all four workflow files.

Every workflow now starts with `permissions: {}` and each job declares only
the permissions it actually needs. All `actions/checkout` steps set
`persist-credentials: false` to avoid leaving tokens on the runner. The two
release compress steps in `release.yml` move GitHub expression interpolation
into `env:` blocks to prevent template injection in shell commands.

The two remaining `secrets-outside-env` alerts are deferred — those actions
require secrets via `with:` inputs by design.