### PR TITLE
ci: replace ncipollo/release-action with gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,12 +126,15 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}-x86_64-apple-darwin.zip
 
-      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+      - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          artifacts: '*.zip,*.tar.xz'
-          bodyFile: 'CHANGELOG.md'
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "${TAG_NAME}" \
+            --title "${TAG_NAME}" \
+            --notes-file CHANGELOG.md \
+            ./*.zip ./*.tar.xz
 
   homebrew:
     name: Bump Homebrew formula


### PR DESCRIPTION
Replace `ncipollo/release-action` with a `gh release create` call to remove a
third-party action from the supply chain. The `gh` CLI is pre-installed on all
GitHub-hosted runners and provides the same release creation, artifact upload,
and changelog body functionality. Resolves zizmor `superfluous-actions` alert #28.