### PR TITLE
ci: zizmor/poutine config and workflow trigger improvements

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master # zizmor: ignore[superfluous-actions]
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -20,7 +20,7 @@ jobs:
         rust: [stable]
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master # zizmor: ignore[superfluous-actions]
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -93,6 +93,10 @@ jobs:
               - 'Cargo.lock'
             workflows:
               - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.poutine.yml'
+              - '.zizmor.yml'
+              - 'renovate.json'
 
   cargo-audit:
     needs: changes

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master # zizmor: ignore[superfluous-actions]
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -77,7 +77,7 @@ jobs:
             toolchain: stable
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master # zizmor: ignore[superfluous-actions]
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
             archive_ext: tar.xz
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master # zizmor: ignore[superfluous-actions]
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           components: rustfmt, clippy

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -8,3 +8,4 @@ skip:
       - pkg:githubactions/zizmorcore/zizmor-action
       - pkg:githubactions/boostsecurityio/poutine-action
       - pkg:githubactions/mislav/bump-homebrew-formula-action
+      - pkg:githubactions/renovatebot/github-action

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  superfluous-actions:
+    ignore:
+      - dtolnay/rust-toolchain

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,4 +1,7 @@
 rules:
   superfluous-actions:
     ignore:
-      - dtolnay/rust-toolchain
+      - cargo-audit.yml
+      - essentials.yml
+      - large-scope.yml
+      - release.yml


### PR DESCRIPTION
Add `renovatebot/github-action` to the poutine allow-list and broaden the
paths-filter in essentials.yml to also trigger ci-security on changes to
`.poutine.yml`, `.zizmor.yml`, `renovate.json`, and `.github/actions/**`.

Move zizmor `superfluous-actions` suppressions from inline comments to a
centralized `.zizmor.yml` config file so they survive Renovate SHA bumps.