### PR TITLE
ci: move zizmor config to .github/zizmor.yml for auto-discovery

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -95,7 +95,7 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
               - '.poutine.yml'
-              - '.zizmor.yml'
+              - '.github/zizmor.yml'
               - 'renovate.json'
 
   cargo-audit:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  # TODO: replace with action-name-based ignore once available
+  # (zizmorcore/zizmor#1086). All occurrences are dtolnay/rust-toolchain,
+  # which is intentional for multi-version matrix builds.
+  superfluous-actions:
+    ignore:
+      - cargo-audit.yml
+      - essentials.yml
+      - large-scope.yml
+      - release.yml

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,7 +1,0 @@
-rules:
-  superfluous-actions:
-    ignore:
-      - cargo-audit.yml
-      - essentials.yml
-      - large-scope.yml
-      - release.yml


### PR DESCRIPTION
The dot-prefixed `.zizmor.yml` at the repo root was not auto-discovered by
zizmor — the config was silently ignored and file-level ignores had no effect.
Moving to `.github/zizmor.yml` (one of zizmor's default discovery paths) fixes
auto-discovery and properly suppresses `superfluous-actions` for workflows using
`dtolnay/rust-toolchain`.

Action-name-based ignores are not yet supported (zizmorcore/zizmor#1086), so
file-level ignores are used as the interim solution.