### PR TITLE
ci: skip cargo cache on pushes to main

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -34,6 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache crates from crates.io
+        if: github.event_name == 'pull_request'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         continue-on-error: false
         with:


### PR DESCRIPTION
Only use the cargo cache on pull requests. Pushes to main now get clean builds
to prevent cache poisoning — a compromised cache on a PR branch could otherwise
propagate to main.