### PR TITLE
ci: replace PATs with GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,15 @@ jobs:
     needs:
       - release
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: graelo
+          repositories: homebrew-tap
+
       - name: Extract version
         id: extract-version
         run: |
@@ -163,7 +172,6 @@ jobs:
         with:
           formula-name: tmux-backup
           homebrew-tap: graelo/homebrew-tap
-          # base-branch: main
           create-pullrequest: true
           download-url: https://github.com/graelo/tmux-backup/archive/refs/tags/${{ steps.extract-version.outputs.tag-name }}.tar.gz
           commit-message: |
@@ -171,4 +179,4 @@ jobs:
 
             Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,6 +20,13 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -29,6 +36,6 @@ jobs:
         uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d # v46.1.8
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           configurationFile: renovate.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "tmux-backup"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "async-fs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-backup"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2024"
 rust-version = "1.88.0"
 description = "A backup & restore solution for Tmux sessions."


### PR DESCRIPTION
Replace the long-lived COMMITTER_TOKEN and RENOVATE_TOKEN PATs with short-lived
tokens generated on the fly via `actions/create-github-app-token`. The homebrew
job token is scoped to the `homebrew-tap` repo only, and the Renovate token is
scoped to the current repo.

After verifying both workflows work, the old PAT secrets (COMMITTER_TOKEN,
RENOVATE_TOKEN) can be deleted from both environments.