### PR TITLE
ci: update renovate gitAuthor to match GitHub App bot identity

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "gitAuthor": "Renovate Bot <84066822+graelo@users.noreply.github.com>",
+  "gitAuthor": "graelo-ci-bot[bot] <274240725+graelo-ci-bot[bot]@users.noreply.github.com>",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
Update the `gitAuthor` in renovate.json to use the graelo-ci-bot identity
instead of the personal noreply email. Renovate now runs as the GitHub App,
so commits and the Dependency Dashboard should use the bot's identity
consistently.

Close old Dependency Dashboard (#52) after merging — the bot created a new
one (#66).