### PR TITLE
fix(ci): correct version comment for bump-homebrew-formula-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4
+      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         if: '!contains(github.ref, ''-'')' # skip prereleases
         with:
           formula-name: tmux-backup


### PR DESCRIPTION
The version comment said `v4` but the SHA corresponds to tag `v4.1`. Unlike most
actions, mislav/bump-homebrew-formula-action has no floating major-version tag,
so Renovate's digest lookup was failing with "Could not determine new digest".