### PR TITLE
ci(release): set artifact retention to 1 day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
           path: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          retention-days: 1
 
   release:
     name: Create a GitHub Release


### PR DESCRIPTION
Set `retention-days: 1` on `upload-artifact` in the release workflow. The default
90-day retention silently eats into the account-wide Actions storage quota
(0.5 GB on Free). These artifacts only need to survive until the release job
downloads them, so 1 day is plenty.