### PR TITLE
chore(ci): tighten workflow consistency

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -52,12 +52,11 @@ jobs:
 
       - name: Quality - cargo clippy
         run: |
-          cargo clippy -- -D warnings
+          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Quality - convco check
         run: |
           git show-ref
-          echo Commit message: "$(git log -1 --pretty=%B)"
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -40,7 +40,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Quality - cargo fmt
         run: |
@@ -61,7 +61,7 @@ jobs:
 
   test-other-platforms:
     name: Tests on
-    runs-on: '${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
@@ -75,12 +75,16 @@ jobs:
             target: aarch64-apple-darwin
             type: unix
             toolchain: stable
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            type: unix
+            toolchain: stable
     steps:
       - name: Rust install
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
           components: rustfmt, clippy
 
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ permissions: {}
 jobs:
   prepare-artifacts:
     name: Prepare release artifacts
-    # if: github.ref == 'refs/heads/main'
-    runs-on: '${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
@@ -40,7 +39,7 @@ jobs:
       - name: Rust install
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Checkout
@@ -83,7 +82,6 @@ jobs:
 
   release:
     name: Create a GitHub Release
-    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -92,7 +90,7 @@ jobs:
     needs:
       - prepare-artifacts
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # convco needs all history to create the changelog
@@ -146,7 +144,6 @@ jobs:
 
   homebrew:
     name: Bump Homebrew formula
-    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,5 +1,5 @@
 # Runs Renovate to check for dependency updates.
-# Triggers weekly on Monday mornings, or manually via workflow_dispatch.
+# Triggers weekly on Friday afternoons, or manually via workflow_dispatch.
 
 name: Renovate
 


### PR DESCRIPTION
Small housekeeping pass on the workflows to make them consistent and catch a few latent issues.

Clippy now runs with --all-targets --all-features so test and example code are linted too. The release matrix was hardcoding toolchain: stable while carrying a matrix.rust column — switched to matrix.rust so the column is actually used. The test matrix gains aarch64-unknown-linux-gnu coverage, and dtolnay/rust-toolchain's target: input is corrected to targets: (the singular form is silently ignored). Assorted cleanup: drop commented-out if: guards in release.yml, normalize runs-on quoting, capitalize a stray step name, and disambiguate a cargo cache key. Renovate schedule comment updated to match its current cron.