### PR TITLE
build(release): switch linux builds to musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
             suffix: ''
             archive_ext: zip
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             rust: stable
             suffix: ''
             archive_ext: tar.xz
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             rust: stable
             suffix: ''
             archive_ext: tar.xz
@@ -40,7 +40,12 @@ jobs:
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
           components: rustfmt, clippy
+
+      - name: Install musl-tools (Linux)
+        if: contains(matrix.target, '-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,7 +54,9 @@ jobs:
           persist-credentials: false
 
       - name: Build Release
-        run: cargo build --release
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --target "${TARGET}"
 
       - name: Compress to zip (macOS)
         if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' }}
@@ -57,7 +64,9 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "target/release/${REPO_NAME}"
+        run: |
+          cp "target/${TARGET}/release/${REPO_NAME}" .
+          zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
 
       - name: Compress to tar.xz (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
@@ -65,12 +74,16 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "target/release/${REPO_NAME}"
+        run: |
+          cp "target/${TARGET}/release/${REPO_NAME}" .
+          tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
 
       - name: List files
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           ls -alF .
-          ls -alF target/release/
+          ls -alF "target/${TARGET}/release/"
         shell: bash
 
       - name: Upload artifacts
@@ -116,10 +129,10 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.event.repository.name }}-x86_64-unknown-linux-gnu.tar.xz
+          name: ${{ github.event.repository.name }}-x86_64-unknown-linux-musl.tar.xz
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.event.repository.name }}-aarch64-unknown-linux-gnu.tar.xz
+          name: ${{ github.event.repository.name }}-aarch64-unknown-linux-musl.tar.xz
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip


### PR DESCRIPTION
Linux release binaries are now statically linked against musl, so they
run on old distros without glibc version constraints and carry no
runtime system library dependencies.

Cross-compile via `--target`, install `musl-tools` on the Linux
runners, and pass the target through to `rustup target add` so the
musl std is available. Archive file names shift from
`tmux-backup-<arch>-unknown-linux-gnu.tar.xz` to
`tmux-backup-<arch>-unknown-linux-musl.tar.xz`. Archives are also
flattened — they now unpack to a bare `tmux-backup` instead of
`target/release/tmux-backup`, matching the layout used by tik and
tmux-copyrat.

Users of the `tmux-backup.tmux` plugin are unaffected (it relies on
`which` rather than release assets). Homebrew and `cargo install`
build from source and are also unaffected. Only manual downloaders of
the Linux tarballs need to update their install steps.