### PR TITLE
build: bump MSRV to 1.95

### DIFF
--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        rust: [1.88.0, beta, nightly]
+        rust: [1.95.0, beta, nightly]
 
     steps:
       - name: Rust install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tmux-backup"
 version = "0.5.16"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "A backup & restore solution for Tmux sessions."
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![crate](https://img.shields.io/crates/v/tmux-backup.svg)](https://crates.io/crates/tmux-backup)
 [![documentation](https://docs.rs/tmux-backup/badge.svg)](https://docs.rs/tmux-backup)
-[![minimum rustc 1.88](https://img.shields.io/badge/rustc-1.88+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
-[![rust 2021 edition](https://img.shields.io/badge/edition-2021-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)
+[![minimum rustc 1.95](https://img.shields.io/badge/rustc-1.95+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![rust 2024 edition](https://img.shields.io/badge/edition-2024-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/index.html)
 [![build status](https://github.com/graelo/tmux-backup/actions/workflows/essentials.yml/badge.svg)](https://github.com/graelo/tmux-backup/actions/workflows/essentials.yml)
 
 <!-- cargo-sync-readme start -->

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=tmux-backup
-MSRV=1.88
+MSRV=1.95
 
 get_rust_version() {
   local array=($(rustc --version));


### PR DESCRIPTION
Bump the minimum supported Rust version from 1.88 to 1.95, matching the
latest stable release. Updated across Cargo.toml, CI matrix, and the
test script.

Also fixed the README edition badge which still said 2021 even though
the crate moved to edition 2024 in a previous release.