### PR TITLE
Switch CI test runner to cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+# cargo-nextest configuration
+# https://nexte.st/docs/configuration/
+
+[profile.default]
+retries = 0
+test-threads = "num-cpus"
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[profile.ci]
+retries = 2
+fail-fast = true

--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -9,3 +9,4 @@ skip:
       - pkg:githubactions/boostsecurityio/poutine-action
       - pkg:githubactions/mislav/bump-homebrew-formula-action
       - pkg:githubactions/renovatebot/github-action
+      - pkg:githubactions/taiki-e/install-action

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Build (release)
         run: cargo build --all-features --release
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
+        with:
+          tool: cargo-nextest@0.9.133
+
       - name: Test
         run: ./ci/test_full.sh
 

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -50,6 +50,11 @@ jobs:
         run: |
           cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
+        with:
+          tool: cargo-nextest@0.9.133
+
       - name: Build (dev)
         run: cargo build --all-features
 
@@ -71,12 +76,12 @@ jobs:
             target: x86_64-apple-darwin
             type: unix
             toolchain: stable
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            type: unix
-            toolchain: stable
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            type: unix
+            toolchain: stable
+          - os: macos-latest
+            target: aarch64-apple-darwin
             type: unix
             toolchain: stable
     steps:
@@ -103,6 +108,11 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
+        with:
+          tool: cargo-nextest@0.9.133
 
       - name: Build (dev)
         run: cargo build --all-features

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,5 +1,5 @@
 # Runs Renovate to check for dependency updates.
-# Triggers weekly on Friday afternoons, or manually via workflow_dispatch.
+# Triggers daily at 19:00 UTC, or manually via workflow_dispatch.
 
 name: Renovate
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -34,24 +34,27 @@ set -x
 
 # test the default
 cargo build
-cargo test --workspace
+cargo nextest run
 
 # test `no_std`
 cargo build --no-default-features
-cargo test --no-default-features --workspace
+cargo nextest run --no-default-features
 
 # test each isolated feature, with and without std
 for feature in "${FEATURES[@]}"; do
   # cargo build --no-default-features --features="std $feature"
-  # cargo test --no-default-features --features="std $feature"
+  # cargo nextest run --no-default-features --features="std $feature"
 
   cargo build --no-default-features --features="$feature"
-  cargo test --no-default-features --features="$feature" --workspace
+  cargo nextest run --no-default-features --features="$feature"
 done
 
 # test all supported features, with and without std
 # cargo build --features="std ${FEATURES[*]}"
-# cargo test --features="std ${FEATURES[*]}"
+# cargo nextest run --features="std ${FEATURES[*]}"
 
 cargo build --features="${FEATURES[*]}"
-cargo test --features="${FEATURES[*]}" --workspace
+cargo nextest run --features="${FEATURES[*]}"
+
+# doc tests (not supported by nextest)
+cargo test --doc


### PR DESCRIPTION
Replace cargo test with cargo-nextest across all CI workflows for faster,
per-test-process execution. Install nextest via taiki-e/install-action
(SHA-pinned) in essentials.yml and both jobs in large-scope.yml. The test
script now finishes with cargo test --doc since nextest doesn't support
doc tests.

Also fixes the stale renovate.yml schedule comment (said "weekly" but the
cron was already daily) and reorders the large-scope platform matrix to
match the cross-repo convention.