### PR TITLE
Use nextest ci profile when running in CI

### DIFF
--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -30,31 +30,36 @@ fi
 FEATURES=()
 echo "Testing supported features: ${FEATURES[*]}"
 
+NEXTEST_PROFILE=""
+if [ -n "$CI" ]; then
+  NEXTEST_PROFILE="--profile ci"
+fi
+
 set -x
 
 # test the default
 cargo build
-cargo nextest run
+cargo nextest run $NEXTEST_PROFILE
 
 # test `no_std`
 cargo build --no-default-features
-cargo nextest run --no-default-features
+cargo nextest run $NEXTEST_PROFILE --no-default-features
 
 # test each isolated feature, with and without std
 for feature in "${FEATURES[@]}"; do
   # cargo build --no-default-features --features="std $feature"
-  # cargo nextest run --no-default-features --features="std $feature"
+  # cargo nextest run $NEXTEST_PROFILE --no-default-features --features="std $feature"
 
   cargo build --no-default-features --features="$feature"
-  cargo nextest run --no-default-features --features="$feature"
+  cargo nextest run $NEXTEST_PROFILE --no-default-features --features="$feature"
 done
 
 # test all supported features, with and without std
 # cargo build --features="std ${FEATURES[*]}"
-# cargo nextest run --features="std ${FEATURES[*]}"
+# cargo nextest run $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
 
 cargo build --features="${FEATURES[*]}"
-cargo nextest run --features="${FEATURES[*]}"
+cargo nextest run $NEXTEST_PROFILE --features="${FEATURES[*]}"
 
 # doc tests (not supported by nextest)
 cargo test --doc


### PR DESCRIPTION
Detect the $CI environment variable in ci/test_full.sh and pass
--profile ci to cargo nextest run. This activates the ci profile
from .config/nextest.toml, which enables retries (2) and fail-fast
— useful defaults for CI that we don't want locally.