### PR TITLE
Add binary installer and align tmux plugin script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# Downloaded binary (install-binary.sh)
+/.installed-version

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# tmux-backup binary installer
+# Downloads the appropriate pre-built binary from GitHub releases.
+# Automatically re-downloads when TPM updates the plugin (version mismatch).
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO="graelo/tmux-backup"
+BINARY="tmux-backup"
+BINARY_PATH="${SCRIPT_DIR}/${BINARY}"
+VERSION_FILE="${SCRIPT_DIR}/.installed-version"
+RELEASES_URL="https://github.com/${REPO}/releases"
+
+FORCE=false
+QUIET=false
+
+log() { $QUIET || echo "[$(date '+%H:%M:%S')] tmux-backup: $1" >&2; }
+die() { echo "[$(date '+%H:%M:%S')] tmux-backup: $1" >&2; exit 1; }
+
+# --- Version check ---
+
+plugin_version() {
+    git -C "$SCRIPT_DIR" describe --tags --abbrev=0 2>/dev/null || echo "unknown"
+}
+
+installed_version() {
+    cat "$VERSION_FILE" 2>/dev/null || echo "unknown"
+}
+
+needs_update() {
+    $FORCE && return 0
+    [[ ! -x "$BINARY_PATH" ]] && return 0
+    [[ "$(plugin_version)" != "$(installed_version)" ]]
+}
+
+# --- Download helpers ---
+
+fetch() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$@"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO- "$@"
+    else
+        die "Error: curl or wget required"
+    fi
+}
+
+download() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -fSL -o "$2" "$1" 2>/dev/null
+    else
+        wget -qO "$2" "$1" 2>/dev/null
+    fi
+}
+
+# --- Core logic ---
+
+install() {
+    needs_update || { log "Up to date ($(installed_version))"; return 0; }
+
+    # Detect platform
+    local os arch
+    case "$(uname -s)" in
+        Darwin) os="darwin" ;; Linux) os="linux" ;; *) die "Unsupported OS: $(uname -s). Install manually: ${RELEASES_URL}" ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64) arch="x86_64" ;; arm64|aarch64) arch="aarch64" ;; *) die "Unsupported arch: $(uname -m). Install manually: ${RELEASES_URL}" ;;
+    esac
+
+    # Build expected asset name
+    local asset
+    if [[ "$os" == "darwin" ]]; then
+        asset="${BINARY}-${arch}-apple-darwin.zip"
+    else
+        asset="${BINARY}-${arch}-unknown-linux-musl.tar.xz"
+    fi
+
+    # Get download URL from GitHub API
+    local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    local release_info
+    release_info=$(fetch "$api_url") || die "Failed to fetch release info. Install manually: ${RELEASES_URL}"
+
+    local url
+    url=$(echo "$release_info" | grep -o "\"browser_download_url\":[[:space:]]*\"[^\"]*${asset}\"" | sed 's/.*"\(http[^"]*\)".*/\1/')
+    [[ -n "$url" ]] || die "No binary found for ${os}-${arch}. Install manually: ${RELEASES_URL}"
+
+    # Download and extract
+    log "Downloading ${asset}..."
+    local tmp="${SCRIPT_DIR}/${asset}"
+    download "$url" "$tmp" || die "Download failed"
+
+    if [[ "$asset" == *.zip ]]; then
+        unzip -qo "$tmp" -d "$SCRIPT_DIR"
+    else
+        tar -xf "$tmp" -C "$SCRIPT_DIR"
+    fi
+    rm -f "$tmp"
+
+    # Find and move binary to expected location
+    local found=""
+    for candidate in "${SCRIPT_DIR}/${BINARY}" "${SCRIPT_DIR}/target/release/${BINARY}" "${SCRIPT_DIR}/release/${BINARY}"; do
+        [[ -f "$candidate" ]] && found="$candidate" && break
+    done
+    [[ -n "$found" ]] || die "Binary not found after extraction"
+
+    if [[ "$found" != "$BINARY_PATH" ]]; then
+        mv "$found" "$BINARY_PATH"
+        # Clean up leftover empty directories
+        local d; d=$(dirname "$found")
+        while [[ "$d" != "$SCRIPT_DIR" ]] && [[ -d "$d" ]]; do
+            rmdir "$d" 2>/dev/null || break
+            d=$(dirname "$d")
+        done
+    fi
+    chmod +x "$BINARY_PATH"
+
+    # Record installed version
+    local ver; ver=$(plugin_version)
+    [[ "$ver" != "unknown" ]] && echo "$ver" > "$VERSION_FILE"
+
+    log "Installed ${ver}"
+}
+
+# --- CLI ---
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            echo "Usage: $0 [-f|--force] [-q|--quiet] [-h|--help]"
+            echo "Downloads tmux-backup binary. Auto-updates when plugin version changes."
+            exit 0 ;;
+        -f|--force) FORCE=true; shift ;;
+        -q|--quiet) QUIET=true; shift ;;
+        *) die "Unknown option: $1" ;;
+    esac
+done
+
+$FORCE && rm -f "$BINARY_PATH" "$VERSION_FILE"
+
+install

--- a/tmux-backup.tmux
+++ b/tmux-backup.tmux
@@ -3,49 +3,84 @@
 # This scripts provides a default configuration for tmux-backup options and
 # key bindings. It is run only once at tmux launch.
 #
-# Each option and binding can be overridden in your `tmux.conf` by defining
-# options like
+# IMPORTANT: DO NOT MODIFY THIS FILE DIRECTLY!
+# If you're using TPM, your changes will be lost when the plugin is updated.
+#
+# Instead, customize the plugin by adding options to your ~/.tmux.conf:
 #
 #   set -g @backup-keytable "foobar"
 #   set -g @backup-keyswitch "z"
 #   set -g @backup-strategy "-s most-recent -n 10"
 #
-# and bindings like
+# and custom bindings like:
 #
 #   bind-key -T foobar l 'tmux-backup catalog list'
+#
+# Please avoid modifying this script as it may break the integration with
+# `tmux-backup`.
 #
 # You can also entirely ignore this file (not even source it) and define all
 # options and bindings in your `tmux.conf`.
 
-BINARY="$(which tmux-backup)"
-# CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
-# BINARY=${CURRENT_DIR}/tmux-backup
+# Get the current directory where this script is located
+CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+# Function to ensure binary is available and up to date
+ensure_binary_available() {
+    local installer_script="${CURRENT_DIR}/install-binary.sh"
+
+    # Always run the installer — it checks version and skips if up to date
+    if [[ -x "$installer_script" ]]; then
+        if "$installer_script" --quiet; then
+            return 0
+        else
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] tmux-backup: Warning: Failed to install binary automatically" >&2
+            return 1
+        fi
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] tmux-backup: Warning: Installer script not found" >&2
+        return 1
+    fi
+}
+
+# Set BINARY variable - prefer system PATH, fall back to local binary
+BINARY=$(which tmux-backup 2>/dev/null || echo "")
+
+# If not found in PATH, try to ensure local binary is available (install if needed)
+if [[ -z "$BINARY" || ! -x "$BINARY" ]]; then
+    ensure_binary_available
+
+    # After ensuring local binary, check if local binary exists
+    if [[ -x "${CURRENT_DIR}/tmux-backup" ]]; then
+        BINARY="${CURRENT_DIR}/tmux-backup"
+    fi
+fi
+
+# Check if we have a usable binary
+if [[ -z "$BINARY" || ! -x "$BINARY" ]]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] tmux-backup: Error: tmux-backup binary not found." >&2
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] tmux-backup: Please install manually or ensure it's in your PATH." >&2
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] tmux-backup: Visit https://github.com/graelo/tmux-backup/releases for manual download." >&2
+    exit 1
+fi
 
 
 #
 # Top-level options
 #
 
-
 setup_option () {
     opt_name=$1
     default_value=$2
-    current_value=$(tmux show-option -gqv @backup-${opt_name})
-    value=$([[ ! -z "${current_value}" ]] && echo "${current_value}" || echo "${default_value}")
-    tmux set-option -g @backup-${opt_name} ${value}
+    current_value=$(tmux show-option -gqv "@backup-${opt_name}")
+    value="${current_value:-$default_value}"
+    tmux set-option -g "@backup-${opt_name}" "${value}"
 }
 
 
-# # Sets the window name which copyrat should use when running, providing a
-# # default value in case @copyrat-window-name was not defined.
-# setup_option "window-name" "[copyrat]"
-
-# # Get that window name as a local variable for use in pattern bindings below.
-# window_name=$(tmux show-option -gqv @copyrat-window-name)
-
 # Sets the keytable for all bindings, providing a default if @backup-keytable
-# was not defined. Keytables open a new shortcut space: if 't' is the switcher
-# (see below), prefix + t + <your-shortcut>
+# was not defined. Keytables open a new shortcut space: if 'b' is the switcher
+# (see below), prefix + b + <your-shortcut>
 setup_option "keytable" "tmuxbackup"
 
 # Sets the key to access the keytable: prefix + <key> + <your-shortcut>
@@ -54,7 +89,7 @@ setup_option "keyswitch" "b"
 
 keyswitch=$(tmux show-option -gv @backup-keyswitch)
 keytable=$(tmux show-option -gv @backup-keytable)
-tmux bind-key ${keyswitch} switch-client -T ${keytable}
+tmux bind-key "${keyswitch}" switch-client -T "${keytable}"
 
 setup_option "strategy" "-s most-recent -n 10"
 strategy=$(tmux show-option -gv @backup-strategy)
@@ -66,13 +101,13 @@ strategy=$(tmux show-option -gv @backup-strategy)
 setup_binding () {
     key=$1
     command="$2"
-    tmux bind-key -T ${keytable} ${key} run-shell "${BINARY} ${command}"
+    tmux bind-key -T "${keytable}" "${key}" run-shell "${BINARY} ${command}"
 }
 
 setup_binding_w_popup () {
     key=$1
     command="$2"
-    tmux bind-key -T ${keytable} ${key} display-popup -E "tmux new-session -A -s tmux-backup '${BINARY} ${command} ; echo Press any key... && read -k1 -s'"
+    tmux bind-key -T "${keytable}" "${key}" display-popup -E "tmux new-session -A -s tmux-backup '${BINARY} ${command} ; echo Press any key... && read -k1 -s'"
 }
 
 # prefix + b + b only saves a new backup without compacting the catalog


### PR DESCRIPTION
Add install-binary.sh, which downloads the correct pre-built binary
from GitHub releases and tracks the installed version so TPM updates
trigger a re-download automatically. This matches the approach already
used in tmux-copyrat.

The tmux-backup.tmux script now tries PATH first, falls back to the
installer, and exits with a clear error if neither works. Also fixes
unquoted variables throughout and adds a "do not modify" header for
TPM users.