### PR TITLE
Enable renovate automerge for patch and minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,14 +21,16 @@
     {
       "description": "Group all patch updates into one PR",
       "matchUpdateTypes": "patch",
-      "groupName": "patch updates"
+      "groupName": "patch updates",
+      "automerge": true
     },
     {
       "description": "Group all minor updates into one PR",
       "matchUpdateTypes": [
         "minor"
       ],
-      "groupName": "minor updates"
+      "groupName": "minor updates",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Add automerge to the patch and minor grouped package rules in
renovate.json so these PRs merge automatically after CI passes.
Major updates still require manual review. Aligns with the
hardening playbook and matches tmux-copyrat's config.