### PR TITLE
Enable renovate platform automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "cargo": {
     "enabled": true
   },
+  "platformAutomerge": true,
   "packageRules": [
     {
       "description": "Pin GitHub Actions to commit SHAs for supply chain safety",


### PR DESCRIPTION
Use GitHub's native auto-merge so Renovate PRs with automerge enabled
merge as soon as CI passes, instead of waiting for the next scheduled
Renovate run.

Requires "Allow auto-merge" to be enabled in repo settings.