### PR TITLE
ci(renovate): set automergeStrategy to merge-commit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
+  "automergeStrategy": "merge-commit",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Set `automergeStrategy: "merge-commit"` in `renovate.json`. Renovate's GitHub-native auto-merge was silently failing with `"Merge method squash merging is not allowed on this repository"` because the ruleset on `main` permits only `[merge, rebase]` and Renovate's default `"auto"` strategy sends `mergeMethod: SQUASH` to the GraphQL `enablePullRequestAutoMerge` mutation. As a result, recent Renovate PRs (e.g., #93, #94) were created with `autoMergeRequest: null` and never auto-merged even after CI passed.

`main`'s first-parent history is exclusively `Merge pull request #N from …` commits, so `"merge-commit"` matches the existing style and is one of the methods the ruleset accepts.

This is the same fix being rolled out to other repos using the `graelo-ci-bot` App.

## Test plan

- [ ] Merge.
- [ ] Trigger a Renovate run (`gh workflow run schedule-renovate.yml`) so existing open Renovate PRs get rebased onto the new `main` and auto-merge re-armed with `mergeMethod: MERGE`.
- [ ] Confirm `gh pr view <N> --json autoMergeRequest` returns a non-null value on the rebased PRs.