### PR TITLE
ci: mirror release targets in compat matrix and align defaults

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+--container-architecture linux/amd64

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -78,20 +78,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
     strategy:
       matrix:
         include:
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            type: unix
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
             toolchain: stable
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            type: unix
+            target: aarch64-unknown-linux-musl
+            toolchain: stable
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
             toolchain: stable
           - os: macos-latest
             target: aarch64-apple-darwin
-            type: unix
             toolchain: stable
     steps:
       - name: Install Rust
@@ -100,6 +105,10 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
           components: rustfmt, clippy
+
+      - name: Install musl-tools (Linux)
+        if: contains(matrix.target, '-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         include:

--- a/src/actions/restore.rs
+++ b/src/actions/restore.rs
@@ -100,7 +100,7 @@ pub async fn restore<P: AsRef<Path>>(backup_filepath: P) -> Result<v1::Overview>
         tmux::server::kill_session(PLACEHOLDER_SESSION_NAME).await?;
         println!(
             "Attach to your last session with `tmux attach -t {}`",
-            &metadata.client.session_name
+            metadata.client.session_name
         );
 
         // Return an overview of the archived tmux environment, which is identical, in principle,
@@ -157,7 +157,7 @@ async fn restore_session(
         let pane_command = format!(
             "cat {} ; exec {}",
             content_filepath.to_string_lossy(),
-            &default_command
+            default_command
         );
 
         let (new_window_id, new_pane_id) = {
@@ -192,7 +192,7 @@ async fn restore_session(
             let pane_command = format!(
                 "cat {} ; exec {}",
                 content_filepath.to_string_lossy(),
-                &default_command
+                default_command
             );
 
             let new_pane_id =

--- a/src/management/catalog.rs
+++ b/src/management/catalog.rs
@@ -215,7 +215,7 @@ impl Catalog {
     }
 
     async fn print_table(&self, details_flag: bool) {
-        println!("Strategy: {}", &self.strategy);
+        println!("Strategy: {}", self.strategy);
 
         // Try to strip the HOME prefix from self.dirpath, otherwise return self.dirpath.
         let location: Cow<Path> = {


### PR DESCRIPTION
Align the compatibility matrix with what the release workflow
actually ships. The job was building aarch64-unknown-linux-gnu
while release ships aarch64-unknown-linux-musl, and never
test-built x86_64-unknown-linux-musl at all — so a libc mismatch
between CI and release would have gone unnoticed. Setting
CARGO_BUILD_TARGET at job level also fixes a quieter bug: cargo
was falling back to the host triple instead of honoring
matrix.target.

While here, add `shell: bash` defaults on the two multi-platform
jobs (compat test-other-platforms, release prepare-artifacts)
and a project-local `.actrc`, matching the playbook reference.
Workflow-only change; the compat matrix triggers on `compat/*`
pushes, so this lands inert until the next compat run.