### PR TITLE
ci: harden release artifacts and drop unused build flags

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,2 +1,2 @@
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
---container-architecture linux/amd64
+-P ubuntu-24.04-arm=catthehacker/ubuntu:act-latest

--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -48,7 +48,7 @@ jobs:
             tar zx --no-anchored cargo-deny --strip-components=1
           chmod +x cargo-deny
           mv cargo-deny ~/.cargo/bin/
-          cargo deny check
+          cargo deny --locked check
 
       - name: Security – cargo pants
         run: |

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --all-targets -- -D warnings
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
@@ -65,10 +65,10 @@ jobs:
           tool: cargo-nextest@0.9.133
 
       - name: Build (dev)
-        run: cargo build --all-features
+        run: cargo build
 
       - name: Build (release)
-        run: cargo build --all-features --release
+        run: cargo build --release
 
       - name: Test
         run: ./ci/test_full.sh
@@ -133,10 +133,10 @@ jobs:
           tool: cargo-nextest@0.9.133
 
       - name: Build (dev)
-        run: cargo build --all-features
+        run: cargo build
 
       - name: Build (release)
-        run: cargo build --all-features --release
+        run: cargo build --release
 
       - name: Test
         run: ./ci/test_full.sh

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -84,6 +84,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Compatibility testing: multi-version and multi-platform matrix.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-other-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
 
 name: 'CI: Compatibility Matrix'
 
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-versions:
+  test-all-versions:
     name: ubuntu-latest (${{ matrix.rust }})
     runs-on: ubuntu-latest
     permissions:
@@ -73,8 +73,8 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-other-platforms:
-    name: ${{ matrix.os }} (stable)
+  test-all-platforms:
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         rust: ['1.95.0', beta, nightly]
@@ -39,36 +42,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache crates
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Quality – cargo fmt
         run: |
           cargo fmt --all -- --check
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets -- -D warnings
+          cargo clippy --locked --all-targets -- -D warnings
+
+      - name: Build (dev)
+        run: cargo build --locked
+
+      - name: Build (release)
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
           tool: cargo-nextest@0.9.133
-
-      - name: Build (dev)
-        run: cargo build
-
-      - name: Build (release)
-        run: cargo build --release
 
       - name: Test
         run: ./ci/test_full.sh
@@ -87,57 +78,42 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            toolchain: stable
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-            toolchain: stable
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            toolchain: stable
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            toolchain: stable
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: aarch64-apple-darwin
+            os: macos-latest
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           targets: ${{ matrix.target }}
-          components: rustfmt, clippy
-
-      - name: Install musl-tools (Linux)
-        if: contains(matrix.target, '-musl')
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Cache crates
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install musl-tools (Linux)
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Build (dev)
+        run: cargo build --locked
+
+      - name: Build (release)
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
           tool: cargo-nextest@0.9.133
-
-      - name: Build (dev)
-        run: cargo build
-
-      - name: Build (release)
-        run: cargo build --release
 
       - name: Test
         run: ./ci/test_full.sh

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets -- -D warnings
+          cargo clippy --locked --all-targets -- -D warnings
 
       - name: Quality – convco check
         run: |
@@ -73,10 +73,10 @@ jobs:
           rm convco
 
       - name: Build (dev)
-        run: cargo build
+        run: cargo build --locked
 
       - name: Build (release)
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --all-targets -- -D warnings
 
       - name: Quality – convco check
         run: |
@@ -73,10 +73,10 @@ jobs:
           rm convco
 
       - name: Build (dev)
-        run: cargo build --all-features
+        run: cargo build
 
       - name: Build (release)
-        run: cargo build --all-features --release
+        run: cargo build --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     defaults:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
@@ -71,31 +74,54 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: cargo build --release --target "${TARGET}"
 
-      - name: Package – compress (zip)
-        if: matrix.archive_ext == 'zip'
+      - name: Package
         env:
-          REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+          ARCHIVE_FORMAT: ${{ matrix.archive_ext }}
+          TAG: ${{ github.ref_name }}
+          BIN: ${{ github.event.repository.name }}
         run: |
-          cp "target/${TARGET}/release/${REPO_NAME}" .
-          zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
+          set -euo pipefail
+          SRC="target/${TARGET}/release/${BIN}"
 
-      - name: Package – compress (tar.xz)
-        if: matrix.archive_ext == 'tar.xz'
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-          TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: |
-          cp "target/${TARGET}/release/${REPO_NAME}" .
-          tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
+          STANDALONE="${BIN}-${TARGET}"
+          cp "${SRC}" "${STANDALONE}"
+
+          PKG_DIR="${BIN}-${TAG}-${TARGET}"
+          mkdir "${PKG_DIR}"
+          cp "${SRC}" "${PKG_DIR}/"
+          cp README.md LICENSE-APACHE LICENSE-MIT "${PKG_DIR}/"
+
+          if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
+            ARCHIVE_FILE="${PKG_DIR}.zip"
+            zip -r "${ARCHIVE_FILE}" "${PKG_DIR}"
+          else
+            ARCHIVE_FILE="${PKG_DIR}.tar.xz"
+            tar -cJf "${ARCHIVE_FILE}" "${PKG_DIR}"
+          fi
+
+          echo "STANDALONE=${STANDALONE}" >> "${GITHUB_ENV}"
+          echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >> "${GITHUB_ENV}"
+
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            ${{ env.STANDALONE }}
+            ${{ env.ARCHIVE_FILE }}
+
+      - name: Upload – standalone
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.STANDALONE }}
+          path: ${{ env.STANDALONE }}
+          retention-days: 1
 
       - name: Upload – archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
-          path: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          name: ${{ env.ARCHIVE_FILE }}
+          path: ${{ env.ARCHIVE_FILE }}
           retention-days: 1
 
   release:
@@ -104,8 +130,6 @@ jobs:
     environment: release
     permissions:
       contents: write
-      id-token: write
-      attestations: write
     needs:
       - prepare-artifacts
     steps:
@@ -133,22 +157,11 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - name: Download – archive (x86_64-unknown-linux-musl)
+      - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.event.repository.name }}-x86_64-unknown-linux-musl.tar.xz
-      - name: Download – archive (aarch64-unknown-linux-musl)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ github.event.repository.name }}-aarch64-unknown-linux-musl.tar.xz
-      - name: Download – archive (aarch64-apple-darwin)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
-      - name: Download – archive (x86_64-apple-darwin)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ github.event.repository.name }}-x86_64-apple-darwin.zip
+          path: artifacts
+          merge-multiple: true
 
       - name: Create GitHub release
         env:
@@ -158,12 +171,7 @@ jobs:
           gh release create "${TAG_NAME}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
-            ./*.zip ./*.tar.xz
-
-      - name: Attest provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: '*.zip,*.tar.xz'
+            ./artifacts/*
 
   homebrew:
     name: Bump Homebrew formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build (release)
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "${TARGET}"
+        run: cargo build --release --locked --target "${TARGET}"
 
       - name: Package
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@
 # Local:
 #   act push -W .github/workflows/release.yml -j prepare-artifacts
 #   act push -W .github/workflows/release.yml -j release
+#   act push -W .github/workflows/release.yml -j homebrew
 
 name: Release
 on:
@@ -31,53 +32,46 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            rust: stable
-            suffix: ''
-            archive_ext: zip
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            rust: stable
-            suffix: ''
-            archive_ext: zip
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            rust: stable
-            suffix: ''
-            archive_ext: tar.xz
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-            rust: stable
-            suffix: ''
-            archive_ext: tar.xz
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.xz
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            archive: tar.xz
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+            archive: tar.xz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.xz
     steps:
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
-          components: rustfmt, clippy
-
-      - name: Install musl-tools (Linux)
-        if: contains(matrix.target, '-musl')
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Install musl-tools (Linux)
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - name: Build (release)
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --locked --target "${TARGET}"
+        run: cargo build --locked --release --target "${TARGET}"
 
-      - name: Package
+      - name: Stage binary and archive
         env:
           TARGET: ${{ matrix.target }}
-          ARCHIVE_FORMAT: ${{ matrix.archive_ext }}
+          ARCHIVE_FORMAT: ${{ matrix.archive }}
           TAG: ${{ github.ref_name }}
           BIN: ${{ github.event.repository.name }}
         run: |
@@ -90,11 +84,11 @@ jobs:
           PKG_DIR="${BIN}-${TAG}-${TARGET}"
           mkdir "${PKG_DIR}"
           cp "${SRC}" "${PKG_DIR}/"
-          cp README.md LICENSE-APACHE LICENSE-MIT "${PKG_DIR}/"
+          cp README.md LICENSE* "${PKG_DIR}/" 2>/dev/null || true
 
           if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
             ARCHIVE_FILE="${PKG_DIR}.zip"
-            zip -r "${ARCHIVE_FILE}" "${PKG_DIR}"
+            7z a "${ARCHIVE_FILE}" "${PKG_DIR}" >/dev/null
           else
             ARCHIVE_FILE="${PKG_DIR}.tar.xz"
             tar -cJf "${ARCHIVE_FILE}" "${PKG_DIR}"
@@ -140,21 +134,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Extract version
-        id: extract-version
-        run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
-
       - name: Install convco
         run: |
-          git show-ref
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco
 
       - name: Generate changelog
         run: |
-          ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
+          ./convco changelog -c .convco --max-versions 1 > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
       - name: Download artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: Build artifacts
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -196,7 +196,7 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - name: Bump formula in graelo/homebrew-tap
+      - name: Bump Homebrew formula
         uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         if: '!contains(github.ref, ''-'')' # skip prereleases
         with:

--- a/README.md
+++ b/README.md
@@ -117,13 +117,24 @@ On macOS
 brew install graelo/homebrew-tap/tmux-backup  # will also install shell completions
 ```
 
-On linux
+On linux, grab the standalone binary for your architecture from the
+[latest release](https://github.com/graelo/tmux-backup/releases/latest)
+(`x86_64-unknown-linux-musl` or `aarch64-unknown-linux-musl`):
 
 ```shell
-curl \
-    https://github.com/graelo/tmux-backup/releases/download/v0.4.0/tmux-backup-x86_64-unknown-linux-gnu.tar.xz \
-    | tar xf - > /usr/local/bin/tmux-backup
+curl -L -o /usr/local/bin/tmux-backup \
+    https://github.com/graelo/tmux-backup/releases/latest/download/tmux-backup-x86_64-unknown-linux-musl
 chmod +x /usr/local/bin/tmux-backup
+```
+
+Or download the archive — it bundles the binary together with the README
+and license files. Pick the version explicitly:
+
+```shell
+VERSION=v0.5.16  # adjust to the desired release
+curl -L https://github.com/graelo/tmux-backup/releases/download/"${VERSION}"/tmux-backup-"${VERSION}"-x86_64-unknown-linux-musl.tar.xz \
+    | tar -xJ
+sudo install -m 755 tmux-backup-"${VERSION}"-x86_64-unknown-linux-musl/tmux-backup /usr/local/bin/
 ```
 
 On linux, to install completions, type
@@ -131,6 +142,25 @@ On linux, to install completions, type
 ```shell
 tmux-backup generate-completion zsh|bash|fish > /path/to/your/completions/folder
 ```
+
+### Verifying release artifacts
+
+Every release artifact ships a build provenance attestation signed by
+GitHub Actions. Verify a download before installing with the
+[GitHub CLI](https://cli.github.com/):
+
+```shell
+# Standalone binary
+gh attestation verify tmux-backup-x86_64-unknown-linux-musl \
+    --repo graelo/tmux-backup
+
+# Archive
+gh attestation verify tmux-backup-v0.5.16-x86_64-unknown-linux-musl.tar.xz \
+    --repo graelo/tmux-backup
+```
+
+Both `.zip` and `.tar.xz` archives plus the standalone binaries for every
+target are covered.
 
 ### Installing the tmux plugin hook
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -38,28 +38,39 @@ fi
 set -x
 
 # test the default
-cargo build
-cargo nextest run $NEXTEST_PROFILE
+cargo build --locked
+cargo nextest run --locked $NEXTEST_PROFILE
 
 # test `no_std`
-cargo build --no-default-features
-cargo nextest run $NEXTEST_PROFILE --no-default-features
+cargo build --locked --no-default-features
+cargo nextest run --locked $NEXTEST_PROFILE --no-default-features
 
 # test each isolated feature, with and without std
 for feature in "${FEATURES[@]}"; do
-  # cargo build --no-default-features --features="std $feature"
-  # cargo nextest run $NEXTEST_PROFILE --no-default-features --features="std $feature"
+  # cargo build --locked --no-default-features --features="std $feature"
+  # cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="std $feature"
 
-  cargo build --no-default-features --features="$feature"
-  cargo nextest run $NEXTEST_PROFILE --no-default-features --features="$feature"
+  cargo build --locked --no-default-features --features="$feature"
+  cargo nextest run --locked $NEXTEST_PROFILE --no-default-features --features="$feature"
 done
 
 # test all supported features, with and without std
-# cargo build --features="std ${FEATURES[*]}"
-# cargo nextest run $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
+# cargo build --locked --features="std ${FEATURES[*]}"
+# cargo nextest run --locked $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
 
-cargo build --features="${FEATURES[*]}"
-cargo nextest run $NEXTEST_PROFILE --features="${FEATURES[*]}"
+cargo build --locked --features="${FEATURES[*]}"
+cargo nextest run --locked $NEXTEST_PROFILE --features="${FEATURES[*]}"
 
 # doc tests (not supported by nextest)
-cargo test --doc
+cargo test --locked --doc
+
+# CLI smoke test (release binary). CARGO_BUILD_TARGET (set in the compat
+# matrix) redirects output to target/<target>/release; Git Bash on Windows
+# reports OSTYPE=msys.
+cargo build --locked --release
+
+BIN="target/${CARGO_BUILD_TARGET:+${CARGO_BUILD_TARGET}/}release/tmux-backup"
+case "${OSTYPE:-}" in
+  msys*|cygwin*) BIN="${BIN}.exe" ;;
+esac
+"${BIN}" --help

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -69,13 +69,12 @@ install() {
         x86_64|amd64) arch="x86_64" ;; arm64|aarch64) arch="aarch64" ;; *) die "Unsupported arch: $(uname -m). Install manually: ${RELEASES_URL}" ;;
     esac
 
-    # Build expected asset name
+    # Build expected standalone-binary asset name
     local asset
-    if [[ "$os" == "darwin" ]]; then
-        asset="${BINARY}-${arch}-apple-darwin.zip"
-    else
-        asset="${BINARY}-${arch}-unknown-linux-musl.tar.xz"
-    fi
+    case "$os" in
+        darwin) asset="${BINARY}-${arch}-apple-darwin" ;;
+        linux)  asset="${BINARY}-${arch}-unknown-linux-musl" ;;
+    esac
 
     # Get download URL from GitHub API
     local api_url="https://api.github.com/repos/${REPO}/releases/latest"
@@ -86,34 +85,9 @@ install() {
     url=$(echo "$release_info" | grep -o "\"browser_download_url\":[[:space:]]*\"[^\"]*${asset}\"" | sed 's/.*"\(http[^"]*\)".*/\1/')
     [[ -n "$url" ]] || die "No binary found for ${os}-${arch}. Install manually: ${RELEASES_URL}"
 
-    # Download and extract
+    # Download standalone binary directly to destination
     log "Downloading ${asset}..."
-    local tmp="${SCRIPT_DIR}/${asset}"
-    download "$url" "$tmp" || die "Download failed"
-
-    if [[ "$asset" == *.zip ]]; then
-        unzip -qo "$tmp" -d "$SCRIPT_DIR"
-    else
-        tar -xf "$tmp" -C "$SCRIPT_DIR"
-    fi
-    rm -f "$tmp"
-
-    # Find and move binary to expected location
-    local found=""
-    for candidate in "${SCRIPT_DIR}/${BINARY}" "${SCRIPT_DIR}/target/release/${BINARY}" "${SCRIPT_DIR}/release/${BINARY}"; do
-        [[ -f "$candidate" ]] && found="$candidate" && break
-    done
-    [[ -n "$found" ]] || die "Binary not found after extraction"
-
-    if [[ "$found" != "$BINARY_PATH" ]]; then
-        mv "$found" "$BINARY_PATH"
-        # Clean up leftover empty directories
-        local d; d=$(dirname "$found")
-        while [[ "$d" != "$SCRIPT_DIR" ]] && [[ -d "$d" ]]; do
-            rmdir "$d" 2>/dev/null || break
-            d=$(dirname "$d")
-        done
-    fi
+    download "$url" "$BINARY_PATH" || die "Download failed"
     chmod +x "$BINARY_PATH"
 
     # Record installed version

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,9 @@
     },
     {
       "description": "Group all patch updates into one PR",
-      "matchUpdateTypes": "patch",
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "groupName": "patch updates",
       "automerge": true
     },


### PR DESCRIPTION
The release workflow now produces both a standalone binary and a
bundled archive per target. The archive includes README and both
LICENSE files alongside the binary — MIT and Apache-2.0 both
require the license to ship with binaries, which was missing
before. The standalone covers the `curl | install` flow.

Build provenance attestation moves to the build job, so the
signature is bound to the runner that produced the artifact
rather than to a separate publish job that downloaded it. The
publish job is correspondingly simpler — one download-artifact
with merge-multiple, one gh release create. `fail-fast: false`
on the build matrix so a flake on one target doesn't cancel the
others.

The Linux install snippet in the README was broken (redirected
tar's output to a file with `>` and pointed at v0.4.0 / wrong
libc), so the install section is rewritten to cover both the
standalone and archive paths and to show how to verify the
attestation with `gh attestation verify`.

Separately, `--all-features` is removed from clippy and build
steps in both CI workflows — Cargo.toml has no `[features]`
table, so the flag was a no-op carrying a misleading signal.