### PR TITLE
ci(renovate): switch automerge strategy to squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
-  "automergeStrategy": "merge-commit",
+  "automergeStrategy": "squash",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
Change the Renovate automerge strategy from `merge-commit` to `squash` so dependency update PRs are squashed into a single commit when auto-merged, keeping the history cleaner.